### PR TITLE
DP-37 add demo buttons

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ const routes: Routes = [
   {
     path: '',
     component: LayoutComponent,
-    data: { showMenu: false },
+    data: { showMenu: false, showDemo: true },
     children: [
       {
         path: 'example',
@@ -18,7 +18,7 @@ const routes: Routes = [
   {
     path: '',
     component: LayoutComponent,
-    data: { showMenu: true },
+    data: { showMenu: true, showDemo: true },
     children: [
       {
         path: 'city-staff',

--- a/src/app/core/layout/layout-material.module.ts
+++ b/src/app/core/layout/layout-material.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [],
   imports: [CommonModule],
-  exports: [MatSidenavModule],
+  exports: [MatSidenavModule, MatButtonModule],
 })
 export class LayoutMaterialModule {}

--- a/src/app/core/layout/layout.component.html
+++ b/src/app/core/layout/layout.component.html
@@ -1,4 +1,15 @@
 <app-header></app-header>
+
+<div
+  *ngIf="showDemo"
+  class="absolute top-4 right-4 grid grid-cols-2 gap-2 justify-center items-center z-50"
+>
+  <a mat-flat-button color="primary" [routerLink]="'/example'">Example</a>
+  <a mat-flat-button color="primary" [routerLink]="'/city-staff/home'"
+    >City Staff</a
+  >
+</div>
+
 <mat-drawer-container>
   <mat-drawer #drawer class="w-64" mode="side" [opened]="showMenu">
     <dp-side-menu></dp-side-menu>

--- a/src/app/core/layout/layout.component.ts
+++ b/src/app/core/layout/layout.component.ts
@@ -7,10 +7,12 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class LayoutComponent implements OnInit {
   showMenu: boolean = false;
+  showDemo: boolean = false;
 
   constructor(private activatedroute: ActivatedRoute) {}
 
   ngOnInit(): void {
     this.showMenu = this.activatedroute.snapshot.data['showMenu'];
+    this.showDemo = this.activatedroute.snapshot.data['showDemo'];
   }
 }


### PR DESCRIPTION
Add demo buttons on the layout. Showing the buttons can be configured on the data provided to the layout component in the route.