### PR TITLE
DP-131 Add ui support to withdraw petition committee user

### DIFF
--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.html
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.html
@@ -1,0 +1,27 @@
+<dp-basic-alert (event)="submit()">
+  <span modal-title>Are you sure you want to withdrawl this petition?</span>
+  <span modal-body class="w-full flex flex-col gap-6">
+    <p>Once this has been withdrawn it can not be undone</p>
+    <div class="flex flex-col w-full gap-4">
+      <button
+        mat-flat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="warn"
+        [mat-dialog-close]="true"
+      >
+        Withdrawl
+      </button>
+      <button
+        mat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="primary"
+        cdkFocusInitial
+        [mat-dialog-close]="false"
+      >
+        Cancel
+      </button>
+    </div>
+  </span>
+</dp-basic-alert>

--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.spec.ts
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertWithdrawlPetitionComponent } from './alert-withdrawl-petition.component';
+
+describe('ConfirmEditPetitionComponent', () => {
+  let component: AlertWithdrawlPetitionComponent;
+  let fixture: ComponentFixture<AlertWithdrawlPetitionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AlertWithdrawlPetitionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AlertWithdrawlPetitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.ts
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'dp-alert-withdrawl-petition',
+  templateUrl: './alert-withdrawl-petition.component.html',
+})
+export class AlertWithdrawlPetitionComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  submit() {}
+}

--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.module.ts
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AlertWithdrawlPetitionComponent } from './alert-withdrawl-petition.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { BasicAlertModule } from 'src/app/shared/basic-alert/basic-alert.module';
+
+@NgModule({
+  declarations: [AlertWithdrawlPetitionComponent],
+  imports: [CommonModule, BasicAlertModule, MatButtonModule, MatDialogModule],
+  exports: [AlertWithdrawlPetitionComponent],
+})
+export class AlertWithdrawlPetitionModule {}

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.html
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.html
@@ -1,0 +1,77 @@
+<dp-basic-alert (event)="submit()">
+  <span modal-title
+    >To confirm your withdraw, please type YES in the text box below.</span
+  >
+  <span modal-body class="w-full flex flex-col gap-6">
+    <p>Once this has been withdrawn it can not be undone</p>
+    <ng-container [ngSwitch]="currentStep$ | async">
+      <ng-container *ngSwitchCase="'loading'">
+        <div class="flex justify-center w-full">
+          <h3 class="leading-7 font-extrabold">Loading</h3>
+        </div>
+
+        <mat-progress-bar
+          mode="indeterminate"
+          color="primary"
+        ></mat-progress-bar>
+      </ng-container>
+      <ng-container class="flex" *ngSwitchCase="'error'">
+        <div class="flex justify-center w-full">
+          <h3 class="leading-7 font-extrabold">An error has occurred</h3>
+        </div>
+
+        <div class="flex flex-row items-center justify-center">
+          <mat-icon
+            class="w-[14px] h-[14px]"
+            [svgIcon]="'custom_icons:c_close'"
+          ></mat-icon>
+          <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
+        </div>
+      </ng-container>
+
+      <ng-container class="flex" *ngSwitchCase="'contents'">
+        <form [formGroup]="formGroup" class="w-full grid grid-cols-1 gap-6">
+          <mat-form-field>
+            <mat-label>Type "YES" to confirm</mat-label>
+            <input type="text" matInput formControlName="code" />
+            <mat-error *ngIf="this.formGroup.get('code')?.errors?.['required']">
+              <div class="flex flex-row items-center">
+                <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
+                <span class="ml-[9px]">This field is required</span>
+              </div>
+            </mat-error>
+            <mat-error *ngIf="this.formGroup.get('code')?.errors?.['pattern']">
+              <div class="flex flex-row items-center">
+                <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
+                <span class="ml-[9px]">type "YES" to confirm</span>
+              </div>
+            </mat-error>
+          </mat-form-field>
+        </form>
+      </ng-container>
+    </ng-container>
+
+    <div class="flex flex-col w-full gap-4">
+      <button
+        [disabled]="!formGroup.valid"
+        mat-flat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="warn"
+        (click)="submit()"
+      >
+        Confirm
+      </button>
+      <button
+        mat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="primary"
+        cdkFocusInitial
+        [mat-dialog-close]="false"
+      >
+        Cancel
+      </button>
+    </div>
+  </span>
+</dp-basic-alert>

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.spec.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmWithdrawlPetitionComponent } from './confirm-withdrawl-petition.component';
+
+describe('ConfirmEditPetitionComponent', () => {
+  let component: ConfirmWithdrawlPetitionComponent;
+  let fixture: ComponentFixture<ConfirmWithdrawlPetitionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConfirmWithdrawlPetitionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmWithdrawlPetitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.ts
@@ -1,0 +1,46 @@
+import { DialogRef } from '@angular/cdk/dialog';
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { WithdrawPetitionService } from 'src/app/logic/petition/withdraw-petition.service';
+
+@Component({
+  selector: 'dp-confirm-withdrawl-petition',
+  templateUrl: './confirm-withdrawl-petition.component.html',
+})
+export class ConfirmWithdrawlPetitionComponent implements OnInit {
+  protected result$!: Subscription;
+  protected error: string | undefined;
+  protected loading$!: Observable<boolean>;
+  protected currentStep$: BehaviorSubject<
+    'loading' | 'empty' | 'contents' | 'error'
+  > = new BehaviorSubject<'loading' | 'empty' | 'contents' | 'error'>(
+    'contents'
+  );
+  public formGroup: FormGroup;
+  constructor(
+    private _fb: FormBuilder,
+
+    @Inject(MAT_DIALOG_DATA) public data: { id: number },
+    private _dialog: MatDialog,
+    private _router: Router
+  ) {
+    this.formGroup = this._fb.group({
+      code: new FormControl('', [
+        Validators.required,
+        Validators.pattern('YES'),
+      ]),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  submit() {}
+}

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.module.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ConfirmWithdrawlPetitionComponent } from './confirm-withdrawl-petition.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { BasicAlertModule } from 'src/app/shared/basic-alert/basic-alert.module';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+@NgModule({
+  declarations: [ConfirmWithdrawlPetitionComponent],
+  imports: [
+    CommonModule,
+    BasicAlertModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatInputModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatIconModule,
+    MatProgressBarModule,
+  ],
+  exports: [ConfirmWithdrawlPetitionComponent],
+})
+export class ConfirmWithdrawlPetitionModule {}

--- a/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.component.html
+++ b/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.component.html
@@ -1,0 +1,46 @@
+<div class="flex flex-col gap-4 w-full">
+  <div class="flex justify-center w-full">
+    <p class="text-xl font-bold">
+      Your petition has been successfully Withdrawn!
+    </p>
+  </div>
+  <div class="flex justify-center w-full">
+    <mat-icon
+      class="w-[26.67px] h-[26.67px]"
+      [svgIcon]="'custom_icons:like'"
+    ></mat-icon>
+  </div>
+  <div class="flex justify-center w-full">
+    <dp-basic-card class="w-[458px] gap-6">
+      <div class="w-full flex flex-col gap-10 max-h-[392px] overflow-y-auto">
+        <h4 class="font-bold leading-5 text-center">
+          A confirmation email has been sent to you.
+        </h4>
+
+        <div class="flex flex-col gap-4">
+          <div class="flex gap-4">
+            <p class="text-sm leading-[18px] font-bold min-w-[88px]">
+              Petition:
+            </p>
+            <p class="text-sm leading-[18px] font-normal">
+              {{ data }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </dp-basic-card>
+  </div>
+
+  <div class="flex justify-center w-full">
+    <button
+      class="w-full max-w-[458px]"
+      type="button"
+      mat-flat-button
+      color="primary"
+      cdkFocusInitial
+      (click)="submit()"
+    >
+      Return Home
+    </button>
+  </div>
+</div>

--- a/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.component.spec.ts
+++ b/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WithdrawlResultComponent } from './withdrawl-result.component';
+
+describe('ResultPetitionComponent', () => {
+  let component: WithdrawlResultComponent;
+  let fixture: ComponentFixture<WithdrawlResultComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [WithdrawlResultComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WithdrawlResultComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.component.ts
+++ b/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'dp-withdrawl-result',
+  templateUrl: './withdrawl-result.component.html',
+})
+export class WithdrawlResultComponent implements OnInit {
+  @Input() data: string = '';
+
+  constructor(private _router: Router, _activatedRoute: ActivatedRoute) {
+    this.data = _activatedRoute.snapshot.params['petition'];
+  }
+
+  ngOnInit(): void {}
+
+  submit() {
+    this._router.navigate(['/committee/home']);
+  }
+}

--- a/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.module.ts
+++ b/src/app/features/view-petition-committee/withdrawl-result/withdrawl-result.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { WithdrawlResultComponent } from './withdrawl-result.component';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
+import { MatButtonModule } from '@angular/material/button';
+import { RouterModule } from '@angular/router';
+import { WithdrawPetitionService } from 'src/app/logic/petition/withdraw-petition.service';
+import { MatIconModule } from '@angular/material/icon';
+
+@NgModule({
+  declarations: [WithdrawlResultComponent],
+  imports: [
+    CommonModule,
+    BasicCardModule,
+    MatButtonModule,
+    RouterModule,
+    MatIconModule,
+  ],
+  exports: [WithdrawlResultComponent],
+  providers: [WithdrawPetitionService],
+})
+export class WithdrawlResultModule {}


### PR DESCRIPTION
Problem: Offer interface support for the process of withdrawing a petition by a user from the committee
Description: A user of the committee can withdraw one of his requests regardless of its status. This scenario starts from the details interface of a petition.
- The user selects the option to withdraw the petition
- A warning window is displayed where it is specified that the action to be carried out is irreversible
- If the user continues with the process, a confirmation window is displayed where he must write "YES" to confirm the withdrawal of the petition
- If the user continues with the process, an interface is displayed with the result of the petition withdrawal operation

Solution:
Add the confirm-withdrawal-petition component
This pop-up dialog warns the user of the irreversibility of the action she is trying to perform, she has the option to continue the process or cancel it

Add the alert-withdrawal-petition component
This dialog requests a confirmation to withdraw the request, the user must write "YES" to finish the process of withdrawing the request

Add the result-withdrawal-petition component
This component displays the result of a successful petition withdrawal operation.