### PR TITLE
DP-159 Add service to manage the endorse now option

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -25,6 +25,22 @@ const routes: Routes = [
       ),
   },
   {
+    path: 'petition/result-confirm-code',
+    component: LayoutComponent,
+    loadChildren: () =>
+      import(
+        './features/result-sign-petition/result-sign-petition.module'
+      ).then((m) => m.ResultSignPetitionModule),
+  },
+  {
+    path: 'petition/confirm-code',
+    component: LayoutComponent,
+    loadChildren: () =>
+      import(
+        './features/confirm-sign-petition/confirm-sign-petition.module'
+      ).then((m) => m.ConfirmSignPetitionModule),
+  },
+  {
     path: 'inactive-petitions',
     component: LayoutComponent,
     loadChildren: () =>

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,6 +17,14 @@ const routes: Routes = [
       import('./features/home/home.module').then((m) => m.HomeModule),
   },
   {
+    path: 'home/:id',
+    component: LayoutComponent,
+    loadChildren: () =>
+      import('./features/sign-petition/sign-petition.module').then(
+        (m) => m.SignPetitionModule
+      ),
+  },
+  {
     path: 'inactive-petitions',
     component: LayoutComponent,
     loadChildren: () =>

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition-routing.module.ts
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ConfirmSignPetitionComponent } from './confirm-sign-petition.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ConfirmSignPetitionComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ConfirmSignPetitionRoutingModule {}

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.component.html
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.component.html
@@ -1,0 +1,72 @@
+<form [formGroup]="formGroup" (ngSubmit)="submit()">
+  <div class="flex w-full justify-center">
+    <div class="flex flex-col w-full max-w-[544px] gap-6">
+      <dp-return-link
+        class="md:hidden flex"
+        [text]="'Back To Home'"
+        (click)="cancel()"
+      ></dp-return-link>
+      <p class="text-lg leading-6 font-bold md:px-6">
+        Enter your verication code.
+      </p>
+      <dp-basic-card>
+        <div class="w-full flex flex-col gap-[10px]">
+          <p>Enter the code that was sent to you.</p>
+          <mat-form-field>
+            <mat-label>Confirmation Code</mat-label>
+            <input type="text" matInput formControlName="code" />
+            <mat-error *ngIf="this.formGroup.get('code')?.errors?.['required']">
+              <div class="flex flex-row items-center">
+                <mat-icon
+                  class="w-[14px] h-[14px]"
+                  [svgIcon]="'custom_icons:c_close'"
+                ></mat-icon>
+                <span class="ml-[9px]">Confirmation Code is required</span>
+              </div>
+            </mat-error>
+          </mat-form-field>
+
+          <div class="flex flex-row gap-4">
+            <p class="text-sm leading-5">Didn’t receive code?</p>
+            <p
+              class="text-sm leading-[18px] font-bold text-primary-500 cursor-pointer"
+            >
+              Re-send
+            </p>
+          </div>
+        </div>
+      </dp-basic-card>
+      <div class="hidden md:flex md:flex-row md:w-full md:justify-end md:gap-4">
+        <button
+          class="hidden md:flex"
+          type="button"
+          mat-button
+          color="primary"
+          (click)="cancel()"
+        >
+          Back
+        </button>
+        <button type="submit" mat-flat-button color="primary" cdkFocusInitial>
+          Continue
+        </button>
+      </div>
+      <div
+        [class]="
+          formGroup.valid
+            ? 'fixed bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden'
+            : 'hidden bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden'
+        "
+      >
+        <button
+          class="w-full"
+          type="submit"
+          mat-flat-button
+          color="primary"
+          cdkFocusInitial
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.component.spec.ts
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmSignPetitionComponent } from './confirm-sign-petition.component';
+
+describe('ConfirmSignPetitionComponent', () => {
+  let component: ConfirmSignPetitionComponent;
+  let fixture: ComponentFixture<ConfirmSignPetitionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ConfirmSignPetitionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmSignPetitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.component.ts
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'dp-confirm-sign-petition',
+  templateUrl: './confirm-sign-petition.component.html',
+})
+export class ConfirmSignPetitionComponent implements OnInit {
+  public formGroup: FormGroup;
+  constructor(private _fb: FormBuilder) {
+    this.formGroup = this._fb.group({
+      code: ['', [Validators.required]],
+    });
+  }
+
+  ngOnInit(): void {}
+  submit() {}
+  cancel() {}
+}

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.module.ts
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ConfirmSignPetitionComponent } from './confirm-sign-petition.component';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { ConfirmSignPetitionRoutingModule } from './confirm-sign-petition-routing.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+
+@NgModule({
+  declarations: [ConfirmSignPetitionComponent],
+  imports: [
+    CommonModule,
+    BasicCardModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatInputModule,
+    MatIconModule,
+    ConfirmSignPetitionRoutingModule,
+    ReturnLinkModule,
+  ],
+})
+export class ConfirmSignPetitionModule {}

--- a/src/app/features/edit-petition/edit-petition-candidate/edit-petition-candidate.component.ts
+++ b/src/app/features/edit-petition/edit-petition-candidate/edit-petition-candidate.component.ts
@@ -84,8 +84,9 @@ export class EditPetitionCandidateComponent implements OnInit, OnChanges {
         .pipe(
           tap((response) => {
             if (response) {
-              this._editPetitionCandidateLogic.formGroupValue =
-                this.formGroup.value;
+              this._editPetitionCandidateLogic.setCandidatePetition(
+                this.formGroup.value
+              );
             }
           })
         )

--- a/src/app/features/edit-petition/edit-petition-issue/edit-petition-issue.component.ts
+++ b/src/app/features/edit-petition/edit-petition-issue/edit-petition-issue.component.ts
@@ -60,8 +60,9 @@ export class EditPetitionIssueComponent implements OnInit, OnChanges {
         .pipe(
           tap((response) => {
             if (response) {
-              this._editPetitionIssueLogic.formGroupValue =
-                this.formGroup.value;
+              this._editPetitionIssueLogic.setIssuePetition(
+                this.formGroup.value
+              );
             }
           })
         )

--- a/src/app/features/edit-petition/edit-petition.component.ts
+++ b/src/app/features/edit-petition/edit-petition.component.ts
@@ -38,8 +38,9 @@ export class EditPetitionComponent implements OnInit, AfterViewInit {
   ) {}
   ngAfterViewInit(): void {
     this.id = this._activatedRoute.snapshot.params['id'];
-    this._editPetitionLogic.petitionId =
-      this._activatedRoute.snapshot.params['id'];
+    this._editPetitionLogic.getPetition(
+      this._activatedRoute.snapshot.params['id']
+    );
   }
   ngOnInit(): void {
     this.result$ = this._editPetitionLogic.result$.subscribe((result) => {

--- a/src/app/features/home/home.component.html
+++ b/src/app/features/home/home.component.html
@@ -34,6 +34,7 @@
         *ngFor="let item of resultData"
         [data]="item"
         [disabled]="disabledFilter"
+        [basicRoute]="'/home/'"
       ></dp-petition-card>
       <ng-container [ngSwitch]="currentStep$ | async">
         <ng-container *ngSwitchCase="'loading'">

--- a/src/app/features/new-petition/new-petition-candidate/new-petition-candidate.component.ts
+++ b/src/app/features/new-petition/new-petition-candidate/new-petition-candidate.component.ts
@@ -51,7 +51,9 @@ export class NewPetitionCandidateComponent implements OnInit {
 
   submit() {
     if (this.formGroup.valid) {
-      this._newPetitionCandidateLogic.formGroupValue = this.formGroup.value;
+      this._newPetitionCandidateLogic.setCandidatePetition(
+        this.formGroup.value
+      );
     }
   }
   cancel() {

--- a/src/app/features/new-petition/new-petition-issue/new-petition-issue.component.ts
+++ b/src/app/features/new-petition/new-petition-issue/new-petition-issue.component.ts
@@ -41,7 +41,7 @@ export class NewPetitionIssueComponent implements OnInit {
 
   submit() {
     if (this.formGroup.valid) {
-      this._newPetitionIssueLogic.formGroupValue = this.formGroup.value;
+      this._newPetitionIssueLogic.setIssuePetition(this.formGroup.value);
     }
   }
   cancel() {

--- a/src/app/features/new-petition/new-petition.component.ts
+++ b/src/app/features/new-petition/new-petition.component.ts
@@ -39,32 +39,32 @@ export class NewPetitionComponent implements OnInit {
     private _router: Router
   ) {
     this.currentStep$ = this._stepLogic._publicCurrentStep$;
-    this._stepLogic.currentStep = 'type';
+    this._stepLogic.setCurrentStep('type');
   }
 
   ngOnInit(): void {}
 
   cancel(step?: 'type' | 'issue' | 'candidate' | 'result') {
     step
-      ? (this._stepLogic.currentStep = step)
+      ? this._stepLogic.setCurrentStep(step)
       : this._router.navigate(['/committee/home']);
   }
 
   submitType(data: string) {
     if (data === 'Issue') {
-      this._stepLogic.currentStep = 'issue';
+      this._stepLogic.setCurrentStep('issue');
     } else if (data === 'Candidate') {
-      this._stepLogic.currentStep = 'candidate';
+      this._stepLogic.setCurrentStep('candidate');
     }
   }
 
   submitIssue(data: IssuePetitionData) {
     this.dataResponse.dataIssue = data;
-    this._stepLogic.currentStep = 'result';
+    this._stepLogic.setCurrentStep('result');
   }
 
   submitCandidate(data: CandidatePetitionData) {
     this.dataResponse.dataCandidate = data;
-    this._stepLogic.currentStep = 'result';
+    this._stepLogic.setCurrentStep('result');
   }
 }

--- a/src/app/features/result-sign-petition/result-sign-petition-routing.module.ts
+++ b/src/app/features/result-sign-petition/result-sign-petition-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ResultSignPetitionComponent } from './result-sign-petition.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ResultSignPetitionComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ResultSignPetitionRoutingModule {}

--- a/src/app/features/result-sign-petition/result-sign-petition.component.html
+++ b/src/app/features/result-sign-petition/result-sign-petition.component.html
@@ -1,0 +1,53 @@
+<div class="flex w-full justify-center">
+  <div class="flex flex-col w-full max-w-[488px] gap-6">
+    <dp-basic-card>
+      <div class="w-full flex flex-col">
+        <div class="flex justify-center">
+          <p class="font-bold text-lg leading-6 w-full text-center">
+            Signature Successfully Received!
+          </p>
+        </div>
+        <div class="flex justify-center pt-4 pb-2 w-full text-center">
+          <p>Your endorsement on the following petition has been saved:</p>
+        </div>
+        <div class="flex justify-center">
+          <p class="font-bold text-base leading-5 w-full text-center">
+            Petition Title
+          </p>
+        </div>
+        <div class="flex justify-center pt-4 pb-9">
+          <mat-icon
+            class="w-[26.67px] h-[26.67px]"
+            [svgIcon]="'custom_icons:like'"
+          ></mat-icon>
+        </div>
+
+        <div class="hidden md:flex md:flex-row md:w-full md:justify-center">
+          <button
+            class="hidden md:flex"
+            type="button"
+            mat-flat-button
+            color="primary"
+            (click)="submit()"
+          >
+            Return to Active Petitions
+          </button>
+        </div>
+      </div>
+    </dp-basic-card>
+
+    <div
+      class="fixed bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden"
+    >
+      <button
+        class="w-full"
+        type="submit"
+        mat-flat-button
+        color="primary"
+        cdkFocusInitial
+      >
+        Return Home
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/features/result-sign-petition/result-sign-petition.component.spec.ts
+++ b/src/app/features/result-sign-petition/result-sign-petition.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResultSignPetitionComponent } from './result-sign-petition.component';
+
+describe('ResultSignPetitionComponent', () => {
+  let component: ResultSignPetitionComponent;
+  let fixture: ComponentFixture<ResultSignPetitionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ResultSignPetitionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ResultSignPetitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/result-sign-petition/result-sign-petition.component.ts
+++ b/src/app/features/result-sign-petition/result-sign-petition.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'dp-result-sign-petition',
+  templateUrl: './result-sign-petition.component.html',
+})
+export class ResultSignPetitionComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+  submit() {}
+}

--- a/src/app/features/result-sign-petition/result-sign-petition.module.ts
+++ b/src/app/features/result-sign-petition/result-sign-petition.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResultSignPetitionComponent } from './result-sign-petition.component';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
+import { MatButtonModule } from '@angular/material/button';
+import { ResultSignPetitionRoutingModule } from './result-sign-petition-routing.module';
+import { MatIconModule } from '@angular/material/icon';
+
+@NgModule({
+  declarations: [ResultSignPetitionComponent],
+  imports: [
+    CommonModule,
+    BasicCardModule,
+    MatButtonModule,
+    ResultSignPetitionRoutingModule,
+    MatIconModule,
+  ],
+})
+export class ResultSignPetitionModule {}

--- a/src/app/features/sign-petition/sign-petition-routing.module.ts
+++ b/src/app/features/sign-petition/sign-petition-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SignPetitionComponent } from './sign-petition.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SignPetitionComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SignPetitionRoutingModule {}

--- a/src/app/features/sign-petition/sign-petition.component.html
+++ b/src/app/features/sign-petition/sign-petition.component.html
@@ -82,7 +82,7 @@
         </ng-container>
         <ng-container class="flex w-full" *ngSwitchCase="'verify'">
           <dp-verify-sign
-            (submitEvent)="submitVerifyData($event)"
+            [dataSignature]="signatureData"
             (cancelEvent)="cancel($event)"
           ></dp-verify-sign>
         </ng-container>

--- a/src/app/features/sign-petition/sign-petition.component.html
+++ b/src/app/features/sign-petition/sign-petition.component.html
@@ -58,6 +58,7 @@
             <dp-sign-this-petition
               [data]="resultData"
               (submitEvent)="submitPersonalData($event)"
+              (cancelEvent)="cancel($event)"
             ></dp-sign-this-petition>
           </div>
         </ng-container>
@@ -75,13 +76,14 @@
               [data]="resultData"
               [dataSignature]="signatureData"
               (submitEvent)="submitPersonalData($event)"
+              (cancelEvent)="cancel($event)"
             ></dp-sign-this-petition>
           </div>
         </ng-container>
         <ng-container class="flex w-full" *ngSwitchCase="'verify'">
           <dp-verify-sign
             (submitEvent)="submitVerifyData($event)"
-            (cancelEvent)="cancelVerifyData($event)"
+            (cancelEvent)="cancel($event)"
           ></dp-verify-sign>
         </ng-container>
       </ng-container>

--- a/src/app/features/sign-petition/sign-petition.component.html
+++ b/src/app/features/sign-petition/sign-petition.component.html
@@ -1,0 +1,105 @@
+<div class="flex justify-center w-full py-12">
+  <div class="flex flex-col max-w-[1197px] w-full gap-4">
+    <div class="">
+      <ng-container [ngSwitch]="currentStep$ | async">
+        <ng-container class="flex" *ngSwitchCase="'view'">
+          <dp-return-link
+            [route]="'/home'"
+            [text]="'Back to Home'"
+          ></dp-return-link>
+        </ng-container>
+        <ng-container class="flex" *ngSwitchCase="'sign'">
+          <dp-return-link
+            class="md:hidden flex"
+            [text]="'Back to Petition'"
+            (click)="currentStep$.next('view')"
+          ></dp-return-link>
+          <dp-return-link
+            class="hidden md:flex"
+            [route]="'/home'"
+            [text]="'Back to Home'"
+          ></dp-return-link>
+        </ng-container>
+      </ng-container>
+    </div>
+
+    <div class="flex flex-col-reverse md:flex-row justify-center gap-6 mt-4">
+      <ng-container [ngSwitch]="currentStep$ | async">
+        <ng-container *ngSwitchCase="'loading'">
+          <div class="flex flex-col items-center w-full">
+            <h3 class="leading-7 font-extrabold">Loading</h3>
+
+            <mat-progress-bar
+              mode="indeterminate"
+              color="primary"
+            ></mat-progress-bar>
+          </div>
+        </ng-container>
+        <ng-container class="flex" *ngSwitchCase="'error'">
+          <div class="flex justify-center w-full">
+            <h3 class="leading-7 font-extrabold">An error has occurred</h3>
+          </div>
+
+          <div class="flex flex-row items-center justify-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
+          </div>
+        </ng-container>
+
+        <ng-container class="flex" *ngSwitchCase="'view'">
+          <div class="flex flex-col gap-5 max-w-[791px] w-full">
+            <dp-petition-view [data]="resultData"></dp-petition-view>
+          </div>
+
+          <div class="hidden md:flex md:max-w-[386px] md:w-full md:h-fit">
+            <dp-sign-this-petition
+              [data]="resultData"
+              (submitEvent)="submitPersonalData($event)"
+            ></dp-sign-this-petition>
+          </div>
+        </ng-container>
+
+        <ng-container class="flex w-full" *ngSwitchCase="'sign'">
+          <div
+            class="hidden md:flex md:flex-col md:gap-5 md:max-w-[791px] md:w-full"
+          >
+            <dp-petition-view [data]="resultData"></dp-petition-view>
+          </div>
+
+          <div class="flex md:max-w-[386px] w-full h-fit">
+            <dp-sign-this-petition
+              class="w-full"
+              [data]="resultData"
+              [dataSignature]="signatureData"
+              (submitEvent)="submitPersonalData($event)"
+            ></dp-sign-this-petition>
+          </div>
+        </ng-container>
+        <ng-container class="flex w-full" *ngSwitchCase="'verify'">
+          <dp-verify-sign
+            (submitEvent)="submitVerifyData($event)"
+            (cancelEvent)="cancelVerifyData($event)"
+          ></dp-verify-sign>
+        </ng-container>
+      </ng-container>
+    </div>
+  </div>
+</div>
+<div
+  class="fixed bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden"
+  *ngIf="(currentStep$ | async) == 'view'"
+>
+  <button
+    class="w-full"
+    type="button"
+    mat-flat-button
+    color="primary"
+    cdkFocusInitial
+    (click)="currentStep$.next('sign')"
+  >
+    Sign Petition
+  </button>
+</div>

--- a/src/app/features/sign-petition/sign-petition.component.spec.ts
+++ b/src/app/features/sign-petition/sign-petition.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SignPetitionComponent } from './sign-petition.component';
+
+describe('SignPetitionComponent', () => {
+  let component: SignPetitionComponent;
+  let fixture: ComponentFixture<SignPetitionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SignPetitionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SignPetitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/sign-petition/sign-petition.component.ts
+++ b/src/app/features/sign-petition/sign-petition.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { GetPetitionService } from 'src/app/logic/petition/get-petition.service';
+import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
 import { FilterData } from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
@@ -14,6 +15,7 @@ import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-
 export class SignPetitionComponent implements OnInit {
   protected resultData: ResponsePetition = {};
   protected result$!: Subscription;
+  protected resultPetition$!: Subscription;
   protected error: string | undefined;
   protected loading$!: Observable<boolean>;
   protected currentStep$: BehaviorSubject<
@@ -22,16 +24,10 @@ export class SignPetitionComponent implements OnInit {
     'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
   >('loading');
   protected signatureData!: SignaturePetitionData;
-  private currentFilter: FilterData[] = [
-    {
-      property: '',
-      value: '',
-      page: 0,
-    },
-  ];
 
   constructor(
     private _committeeLogic: GetPetitionService,
+
     private _activatedRoute: ActivatedRoute
   ) {}
   ngAfterViewInit(): void {
@@ -49,17 +45,11 @@ export class SignPetitionComponent implements OnInit {
         this.currentStep$.next('error');
       }
     });
-    this.loading$ = this._committeeLogic.loading$;
   }
 
   protected submitPersonalData(data: SignaturePetitionData) {
     this.signatureData = data;
     this.currentStep$.next('verify');
-  }
-
-  protected submitVerifyData(data: SignaturePetitionType) {
-    this.signatureData.verify = data;
-    console.log(this.signatureData);
   }
 
   protected cancel(

--- a/src/app/features/sign-petition/sign-petition.component.ts
+++ b/src/app/features/sign-petition/sign-petition.component.ts
@@ -31,8 +31,9 @@ export class SignPetitionComponent implements OnInit {
     private _activatedRoute: ActivatedRoute
   ) {}
   ngAfterViewInit(): void {
-    this._committeeLogic.petitionId =
-      this._activatedRoute.snapshot.params['id'];
+    this._committeeLogic.getPetition(
+      this._activatedRoute.snapshot.params['id']
+    );
   }
   ngOnInit(): void {
     this.result$ = this._committeeLogic.result$.subscribe((result) => {

--- a/src/app/features/sign-petition/sign-petition.component.ts
+++ b/src/app/features/sign-petition/sign-petition.component.ts
@@ -62,10 +62,12 @@ export class SignPetitionComponent implements OnInit {
     console.log(this.signatureData);
   }
 
-  protected cancelVerifyData(
+  protected cancel(
     value: 'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
   ) {
-    this.signatureData.verify = { verifyType: '' };
+    if (value === 'sign') {
+      this.signatureData.verify = { verifyType: '' };
+    }
 
     this.currentStep$.next(value);
   }

--- a/src/app/features/sign-petition/sign-petition.component.ts
+++ b/src/app/features/sign-petition/sign-petition.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { GetPetitionService } from 'src/app/logic/petition/get-petition.service';
+import { FilterData } from 'src/app/shared/models/exports';
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
+import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-petition-type';
+
+@Component({
+  selector: 'dp-sign-petition',
+  templateUrl: './sign-petition.component.html',
+})
+export class SignPetitionComponent implements OnInit {
+  protected resultData: ResponsePetition = {};
+  protected result$!: Subscription;
+  protected error: string | undefined;
+  protected loading$!: Observable<boolean>;
+  protected currentStep$: BehaviorSubject<
+    'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  > = new BehaviorSubject<
+    'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  >('loading');
+  protected signatureData!: SignaturePetitionData;
+  private currentFilter: FilterData[] = [
+    {
+      property: '',
+      value: '',
+      page: 0,
+    },
+  ];
+
+  constructor(
+    private _committeeLogic: GetPetitionService,
+    private _activatedRoute: ActivatedRoute
+  ) {}
+  ngAfterViewInit(): void {
+    this._committeeLogic.petitionId =
+      this._activatedRoute.snapshot.params['id'];
+  }
+  ngOnInit(): void {
+    this.result$ = this._committeeLogic.result$.subscribe((result) => {
+      if (!!result.result) {
+        this.resultData = result.result;
+
+        this.currentStep$.next('view');
+      } else {
+        this.error = result.error;
+        this.currentStep$.next('error');
+      }
+    });
+    this.loading$ = this._committeeLogic.loading$;
+  }
+
+  protected submitPersonalData(data: SignaturePetitionData) {
+    this.signatureData = data;
+    this.currentStep$.next('verify');
+  }
+
+  protected submitVerifyData(data: SignaturePetitionType) {
+    this.signatureData.verify = data;
+    console.log(this.signatureData);
+  }
+
+  protected cancelVerifyData(
+    value: 'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  ) {
+    this.signatureData.verify = { verifyType: '' };
+
+    this.currentStep$.next(value);
+  }
+}

--- a/src/app/features/sign-petition/sign-petition.module.ts
+++ b/src/app/features/sign-petition/sign-petition.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SignPetitionComponent } from './sign-petition.component';
+import { SignPetitionRoutingModule } from './sign-petition-routing.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { PetitionViewModule } from 'src/app/shared/petition-view/petition-view.module';
+import { GetPetitionService } from 'src/app/logic/petition/get-petition.service';
+import { SignThisPetitionModule } from './sign-this-petition/sign-this-petition.module';
+import { MatButtonModule } from '@angular/material/button';
+import { VerifySignModule } from './verify-sign/verify-sign.module';
+
+@NgModule({
+  declarations: [SignPetitionComponent],
+  imports: [
+    CommonModule,
+    SignPetitionRoutingModule,
+    ReturnLinkModule,
+    MatProgressBarModule,
+    MatButtonModule,
+    MatIconModule,
+    PetitionViewModule,
+    SignThisPetitionModule,
+    VerifySignModule,
+  ],
+  providers: [GetPetitionService],
+})
+export class SignPetitionModule {}

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.html
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.html
@@ -106,11 +106,20 @@
           Continue
         </button>
         <button
-          class="w-full"
+          class="hidden md:flex md:w-full md:justify-center"
           type="button"
           mat-button
           color="primary"
-          (click)="cancel()"
+          [routerLink]="'/home'"
+        >
+          Cancel
+        </button>
+        <button
+          class="md:hidden flex w-full justify-center"
+          type="button"
+          mat-button
+          color="primary"
+          (click)="cancel('view')"
         >
           Cancel
         </button>

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.html
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.html
@@ -1,0 +1,120 @@
+<div
+  class="flex flex-col gap-4 rounded-xl py-8 px-4 md:px-6 bg-[#FFFFFF] border border-[#D7D7D7] shadow-sm"
+>
+  <div class="hidden md:flex md:flex-col md:w-full md:gap-2" *ngIf="totalSign">
+    <mat-progress-bar
+      color="primary"
+      [value]="percent"
+      [bufferValue]="totalSign"
+    ></mat-progress-bar>
+    <p class="text-[14px] leading-[18px] font-normal">
+      {{ currentSign }} / {{ totalSign }} Signatures Subminted
+    </p>
+  </div>
+  <p class="font-bold text-lg leading-6">Sign This Petition</p>
+  <form
+    [formGroup]="formGroup"
+    (ngSubmit)="submit()"
+    class="flex flex-col gap-6"
+  >
+    <div class="w-full flex flex-col gap-6">
+      <mat-form-field>
+        <mat-label>Name</mat-label>
+        <input type="text" matInput formControlName="fullName" />
+        <mat-error *ngIf="this.formGroup.get('fullName')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">Name is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Address</mat-label>
+        <input type="text" matInput formControlName="address" />
+        <mat-error *ngIf="this.formGroup.get('address')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">Address is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>City</mat-label>
+        <input type="text" matInput formControlName="city" />
+        <mat-error *ngIf="this.formGroup.get('city')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">City is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>State</mat-label>
+        <mat-select formControlName="state">
+          <mat-option>--</mat-option>
+          <mat-option *ngFor="let state of localStates" [value]="state">{{
+            state.name
+          }}</mat-option>
+        </mat-select>
+        <mat-error *ngIf="this.formGroup.get('state')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">State is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Zip Code</mat-label>
+        <input type="text" matInput formControlName="zipCode" />
+        <mat-error *ngIf="this.formGroup.get('zipCode')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">Zip Code is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+      <p class="text-xs text-[#5C5C5C] italic">
+        Please use the address where you are registered to vote.
+      </p>
+      <div class="flex flex-col justify-center w-full gap-[15px]">
+        <button
+          class="w-full"
+          type="submit"
+          mat-flat-button
+          color="primary"
+          cdkFocusInitial
+        >
+          Continue
+        </button>
+        <button
+          class="w-full"
+          type="button"
+          mat-button
+          color="primary"
+          (click)="cancel()"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.spec.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SignThisPetitionComponent } from './sign-this-petition.component';
+
+describe('SignThisPetitionComponent', () => {
+  let component: SignThisPetitionComponent;
+  let fixture: ComponentFixture<SignThisPetitionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SignThisPetitionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SignThisPetitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
@@ -1,0 +1,75 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { state, states } from 'src/app/core/states';
+import { Result } from 'src/app/shared/models/exports';
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
+
+@Component({
+  selector: 'dp-sign-this-petition',
+  templateUrl: './sign-this-petition.component.html',
+})
+export class SignThisPetitionComponent implements OnInit, OnChanges {
+  @Input() data: ResponsePetition = {};
+  @Input() dataSignature: SignaturePetitionData = {
+    address: '',
+    city: '',
+    fullName: '',
+    state: { name: '', value: '' },
+    zipCode: '',
+  };
+  protected currentSign: number | undefined = 0;
+  protected totalSign: number | undefined;
+  protected percent: number = 0;
+
+  public formGroup: FormGroup;
+  protected localStates: state[] = states;
+  @Input() offices: string[] = ['Office-1', 'Office-2', 'Office-3', 'Office-4'];
+  @Input() parties: string[] = ['Party-1', 'Party-2', 'Party-3', 'Party-4'];
+
+  @Output() cancelEvent: EventEmitter<void> = new EventEmitter<void>();
+  @Output() submitEvent: EventEmitter<SignaturePetitionData> =
+    new EventEmitter<SignaturePetitionData>();
+
+  constructor(private _fb: FormBuilder) {
+    this.formGroup = this._fb.group({
+      fullName: [this.dataSignature.fullName, [Validators.required]],
+      address: [this.dataSignature.address, [Validators.required]],
+      city: [this.dataSignature.city, [Validators.required]],
+      state: [this.dataSignature.state, [Validators.required]],
+      zipCode: [this.dataSignature.zipCode, [Validators.required]],
+    });
+  }
+
+  submit() {
+    if (this.formGroup.valid) {
+      this.submitEvent.emit(this.formGroup.value);
+    }
+  }
+  cancel() {
+    this.cancelEvent.emit();
+  }
+
+  ngOnInit(): void {}
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!!this.data.dataCandidate) {
+      this.currentSign = this.data.dataCandidate.atributes?.currentSign;
+      this.totalSign = this.data.dataCandidate.atributes?.totalSign;
+    } else if (!!this.data.dataIssue) {
+      this.currentSign = this.data.dataIssue.atributes?.currentSign;
+      this.totalSign = this.data.dataIssue.atributes?.totalSign;
+    }
+    if (!!this.currentSign && !!this.totalSign) {
+      this.percent = (this.currentSign / this.totalSign) * 100;
+    }
+  }
+}

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
@@ -36,7 +36,11 @@ export class SignThisPetitionComponent implements OnInit, OnChanges {
   @Input() offices: string[] = ['Office-1', 'Office-2', 'Office-3', 'Office-4'];
   @Input() parties: string[] = ['Party-1', 'Party-2', 'Party-3', 'Party-4'];
 
-  @Output() cancelEvent: EventEmitter<void> = new EventEmitter<void>();
+  @Output() cancelEvent: EventEmitter<
+    'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  > = new EventEmitter<
+    'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  >();
   @Output() submitEvent: EventEmitter<SignaturePetitionData> =
     new EventEmitter<SignaturePetitionData>();
 
@@ -55,8 +59,8 @@ export class SignThisPetitionComponent implements OnInit, OnChanges {
       this.submitEvent.emit(this.formGroup.value);
     }
   }
-  cancel() {
-    this.cancelEvent.emit();
+  cancel(value: 'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error') {
+    this.cancelEvent.emit(value);
   }
 
   ngOnInit(): void {}

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
@@ -49,7 +49,10 @@ export class SignThisPetitionComponent implements OnInit, OnChanges {
       fullName: [this.dataSignature.fullName, [Validators.required]],
       address: [this.dataSignature.address, [Validators.required]],
       city: [this.dataSignature.city, [Validators.required]],
-      state: [this.dataSignature.state, [Validators.required]],
+      state: [
+        this.dataSignature.state.name === '' ? null : this.dataSignature.state,
+        [Validators.required],
+      ],
       zipCode: [this.dataSignature.zipCode, [Validators.required]],
     });
   }
@@ -64,6 +67,7 @@ export class SignThisPetitionComponent implements OnInit, OnChanges {
   }
 
   ngOnInit(): void {}
+
   ngOnChanges(changes: SimpleChanges): void {
     if (!!this.data.dataCandidate) {
       this.currentSign = this.data.dataCandidate.atributes?.currentSign;

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.module.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.module.ts
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [SignThisPetitionComponent],
@@ -19,6 +20,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     MatSelectModule,
     FormsModule,
     ReactiveFormsModule,
+    RouterModule,
   ],
   exports: [SignThisPetitionComponent],
 })

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.module.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SignThisPetitionComponent } from './sign-this-petition.component';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [SignThisPetitionComponent],
+  imports: [
+    CommonModule,
+    MatProgressBarModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSelectModule,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
+  exports: [SignThisPetitionComponent],
+})
+export class SignThisPetitionModule {}

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.html
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.html
@@ -1,0 +1,142 @@
+<form
+  [formGroup]="formGroup"
+  class="flex flex-col w-full max-w-[632px] gap-6"
+  (submit)="submit()"
+>
+  <dp-return-link
+    class="md:hidden flex"
+    [text]="'Back To Signing'"
+    (click)="cancel('sign')"
+  ></dp-return-link>
+  <div class="flex flex-col gap-2 md:px-6">
+    <p class="font-bold text-lg leading-6">Verify Your Signataure</p>
+    <p>Choose how you want to verify your signature</p>
+  </div>
+  <mat-radio-group
+    class="flex flex-col w-full gap-4"
+    formControlName="verifyType"
+    color="primary"
+  >
+    <dp-basic-card class="flex flex-col w-full">
+      <mat-radio-button value="license"
+        ><p class="font-bold text-base leading-5">
+          Divers License / State ID
+        </p></mat-radio-button
+      >
+      <form
+        *ngIf="formGroup.value.verifyType === 'license'"
+        [formGroup]="formGroupLicense"
+        class="flex md:flex-row flex-col w-full gap-[26px]"
+      >
+        <mat-form-field class="md:max-w-[385px] w-full">
+          <mat-label>License Number</mat-label>
+          <input type="text" matInput formControlName="licenseNumber" />
+          <mat-error
+            *ngIf="this.formGroup.get('licenseNumber')?.errors?.['required']"
+          >
+            <div class="flex flex-row items-center">
+              <mat-icon
+                class="w-[14px] h-[14px]"
+                [svgIcon]="'custom_icons:c_close'"
+              ></mat-icon>
+              <span class="ml-[9px]">License Number is required</span>
+            </div>
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field class="md:max-w-[170px] w-full">
+          <mat-label>Date Of Birth</mat-label>
+          <input
+            matInput
+            [matDatepicker]="picker"
+            formControlName="dateOfBirth"
+          />
+          <mat-datepicker-toggle
+            matPrefix
+            [for]="picker"
+          ></mat-datepicker-toggle>
+          <mat-datepicker #picker></mat-datepicker>
+          <mat-error
+            *ngIf="this.formGroup.get('dateOfBirth')?.errors?.['required']"
+          >
+            <div class="flex flex-row items-center">
+              <mat-icon
+                class="w-[14px] h-[14px]"
+                [svgIcon]="'custom_icons:c_close'"
+              ></mat-icon>
+              <span class="ml-[9px]">Date Of Birth is required</span>
+            </div>
+          </mat-error>
+        </mat-form-field>
+      </form>
+    </dp-basic-card>
+    <dp-basic-card class="flex flex-col w-full">
+      <mat-radio-button value="Email"
+        ><p class="font-bold text-base leading-5">Email</p></mat-radio-button
+      >
+      <p>
+        A confirmation code will be sent to the email address on file with your
+        voter registration.
+      </p>
+    </dp-basic-card>
+    <dp-basic-card class="flex flex-col w-full">
+      <mat-radio-button value="Text"
+        ><p class="font-bold text-base leading-5">Text</p></mat-radio-button
+      >
+      <p>
+        A confirmation code will be sent to the mobile number registered on file
+        with your voter registration.
+      </p>
+    </dp-basic-card>
+    <dp-basic-card class="flex flex-col w-full">
+      <mat-radio-button value="Call"
+        ><p class="font-bold text-base leading-5">Call</p></mat-radio-button
+      >
+      <p>
+        You will receive a phone call to the number that is on file with your
+        voter registration.
+      </p>
+    </dp-basic-card>
+    <dp-basic-card class="flex flex-col w-full">
+      <mat-radio-button value="USMail"
+        ><p class="font-bold text-base leading-5">
+          U.S. Mail
+        </p></mat-radio-button
+      >
+      <p>
+        A confirmation code will be mailed to the address on file with your
+        voter registration.
+      </p>
+    </dp-basic-card>
+  </mat-radio-group>
+  <div class="hidden md:flex md:flex-row md:w-full md:justify-end md:gap-4">
+    <button
+      class="hidden md:flex"
+      type="button"
+      mat-button
+      color="primary"
+      (click)="cancel('view')"
+    >
+      Back
+    </button>
+    <button type="submit" mat-flat-button color="primary" cdkFocusInitial>
+      Continue
+    </button>
+  </div>
+  <div
+    [class]="
+      formGroup.valid
+        ? 'fixed bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden'
+        : 'hidden bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden'
+    "
+  >
+    <button
+      class="w-full"
+      type="submit"
+      mat-flat-button
+      color="primary"
+      cdkFocusInitial
+    >
+      Continue
+    </button>
+  </div>
+</form>

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.html
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.html
@@ -124,7 +124,7 @@
   </div>
   <div
     [class]="
-      formGroup.valid
+      (isContinue$ | async)
         ? 'fixed bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden'
         : 'hidden bottom-0 right-0 left-0 justify-center items-center z-50 py-3 px-6 bg-white md:hidden'
     "

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.html
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.html
@@ -12,6 +12,22 @@
     <p class="font-bold text-lg leading-6">Verify Your Signataure</p>
     <p>Choose how you want to verify your signature</p>
   </div>
+  <ng-container *ngIf="!(loading$ | async)">
+    <ng-container *ngIf="result$ | async as result">
+      <div *ngIf="result.error as error" class="flex flex-row items-center">
+        <mat-icon
+          class="w-[14px] h-[14px]"
+          [svgIcon]="'custom_icons:c_close'"
+        ></mat-icon>
+        <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
+      </div>
+    </ng-container>
+  </ng-container>
+  <mat-progress-bar
+    mode="indeterminate"
+    color="primary"
+    *ngIf="loading$ | async"
+  ></mat-progress-bar>
   <mat-radio-group
     class="flex flex-col w-full gap-4"
     formControlName="verifyType"

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.spec.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VerifySignComponent } from './verify-sign.component';
+
+describe('VerifySignComponent', () => {
+  let component: VerifySignComponent;
+  let fixture: ComponentFixture<VerifySignComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VerifySignComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VerifySignComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { map, merge, Observable, tap } from 'rxjs';
 
 import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-petition-type';
 
@@ -10,6 +11,7 @@ import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-
 export class VerifySignComponent implements OnInit {
   protected formGroup: FormGroup;
   protected formGroupLicense: FormGroup;
+  protected isContinue$: Observable<boolean>;
   @Output() submitEvent: EventEmitter<SignaturePetitionType> =
     new EventEmitter<SignaturePetitionType>();
   @Output() cancelEvent: EventEmitter<
@@ -25,12 +27,27 @@ export class VerifySignComponent implements OnInit {
       licenseNumber: ['', [Validators.required]],
       dateOfBirth: ['', [Validators.required]],
     });
+    this.isContinue$ = merge(
+      this.formGroup.valueChanges,
+      this.formGroupLicense.valueChanges
+    ).pipe(
+      map(() => {
+        return this.formGroup.valid
+          ? this.formGroup.value.verifyType === 'license'
+            ? this.formGroupLicense.valid
+              ? true
+              : false
+            : true
+          : false;
+      })
+    );
   }
 
   ngOnInit(): void {}
   cancel(value: 'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error') {
     this.cancelEvent.emit(value);
   }
+
   submit() {
     if (this.formGroup.valid) {
       if (this.formGroup.value.verifyType === 'license') {

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -87,7 +87,7 @@ export class VerifySignComponent implements OnInit {
           verifyType: this.formGroup.value.verifyType,
         };
       }
-      this._signPetitionLogic.formGroupValue = this.dataSignature;
+      this._signPetitionLogic.setSignaturePetiton(this.dataSignature);
     }
   }
 }

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -1,0 +1,53 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-petition-type';
+
+@Component({
+  selector: 'dp-verify-sign',
+  templateUrl: './verify-sign.component.html',
+})
+export class VerifySignComponent implements OnInit {
+  protected formGroup: FormGroup;
+  protected formGroupLicense: FormGroup;
+  @Output() submitEvent: EventEmitter<SignaturePetitionType> =
+    new EventEmitter<SignaturePetitionType>();
+  @Output() cancelEvent: EventEmitter<
+    'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  > = new EventEmitter<
+    'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
+  >();
+  constructor(private _fb: FormBuilder) {
+    this.formGroup = this._fb.group({
+      verifyType: ['', [Validators.required]],
+    });
+    this.formGroupLicense = this._fb.group({
+      licenseNumber: ['', [Validators.required]],
+      dateOfBirth: ['', [Validators.required]],
+    });
+  }
+
+  ngOnInit(): void {}
+  cancel(value: 'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error') {
+    this.cancelEvent.emit(value);
+  }
+  submit() {
+    if (this.formGroup.valid) {
+      if (this.formGroup.value.verifyType === 'license') {
+        if (this.formGroupLicense.valid) {
+          this.submitEvent.emit({
+            verifyType: this.formGroup.value.verifyType,
+            licenseNumber: this.formGroupLicense.value.licenseNumber,
+            dateOfBirth: this.formGroupLicense.value.dateOfBirth,
+          });
+        } else {
+          this.formGroupLicense.markAllAsTouched();
+        }
+      } else {
+        this.submitEvent.emit({
+          verifyType: this.formGroup.value.verifyType,
+        });
+      }
+    }
+  }
+}

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -1,6 +1,10 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { map, merge, Observable, tap } from 'rxjs';
+import { Router } from '@angular/router';
+import { map, merge, Observable, Subscription, tap } from 'rxjs';
+import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
+import { Result } from 'src/app/shared/models/exports';
+import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
 
 import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-petition-type';
 
@@ -9,17 +13,24 @@ import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-
   templateUrl: './verify-sign.component.html',
 })
 export class VerifySignComponent implements OnInit {
+  @Input() dataSignature!: SignaturePetitionData;
   protected formGroup: FormGroup;
   protected formGroupLicense: FormGroup;
   protected isContinue$: Observable<boolean>;
-  @Output() submitEvent: EventEmitter<SignaturePetitionType> =
-    new EventEmitter<SignaturePetitionType>();
+  protected result$!: Observable<Result<string>>;
+  protected error: string | undefined;
+  protected loading$!: Observable<boolean>;
+
   @Output() cancelEvent: EventEmitter<
     'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
   > = new EventEmitter<
     'loading' | 'verify' | 'empty' | 'view' | 'sign' | 'error'
   >();
-  constructor(private _fb: FormBuilder) {
+  constructor(
+    private _fb: FormBuilder,
+    private _signPetitionLogic: SignPetitionService,
+    private _router: Router
+  ) {
     this.formGroup = this._fb.group({
       verifyType: ['', [Validators.required]],
     });
@@ -41,6 +52,17 @@ export class VerifySignComponent implements OnInit {
           : false;
       })
     );
+
+    this.result$ = this._signPetitionLogic.result$.pipe(
+      tap((result) => {
+        if (!!result.result) {
+          this._router.navigate(['/petition/confirm-code']);
+        } else {
+          this.error = result.error;
+        }
+      })
+    );
+    this.loading$ = this._signPetitionLogic.loading$;
   }
 
   ngOnInit(): void {}
@@ -52,19 +74,20 @@ export class VerifySignComponent implements OnInit {
     if (this.formGroup.valid) {
       if (this.formGroup.value.verifyType === 'license') {
         if (this.formGroupLicense.valid) {
-          this.submitEvent.emit({
+          this.dataSignature.verify = {
             verifyType: this.formGroup.value.verifyType,
             licenseNumber: this.formGroupLicense.value.licenseNumber,
             dateOfBirth: this.formGroupLicense.value.dateOfBirth,
-          });
+          };
         } else {
           this.formGroupLicense.markAllAsTouched();
         }
       } else {
-        this.submitEvent.emit({
+        this.dataSignature.verify = {
           verifyType: this.formGroup.value.verifyType,
-        });
+        };
       }
+      this._signPetitionLogic.formGroupValue = this.dataSignature;
     }
   }
 }

--- a/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
@@ -10,6 +10,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [VerifySignComponent],
@@ -25,6 +27,8 @@ import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module'
     MatDatepickerModule,
     MatNativeDateModule,
     ReturnLinkModule,
+    MatProgressBarModule,
+    RouterModule,
   ],
   exports: [VerifySignComponent],
 })

--- a/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
@@ -12,6 +12,7 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { RouterModule } from '@angular/router';
+import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
 
 @NgModule({
   declarations: [VerifySignComponent],
@@ -31,5 +32,6 @@ import { RouterModule } from '@angular/router';
     RouterModule,
   ],
   exports: [VerifySignComponent],
+  providers: [SignPetitionService],
 })
 export class VerifySignModule {}

--- a/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
@@ -1,0 +1,31 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VerifySignComponent } from './verify-sign.component';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+
+@NgModule({
+  declarations: [VerifySignComponent],
+  imports: [
+    CommonModule,
+    BasicCardModule,
+    MatRadioModule,
+    MatInputModule,
+    MatIconModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    ReturnLinkModule,
+  ],
+  exports: [VerifySignComponent],
+})
+export class VerifySignModule {}

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.ts
@@ -54,6 +54,6 @@ export class ConfirmWithdrawlPetitionComponent implements OnInit {
 
   submit() {
     this.currentStep$.next('loading');
-    this._withdrawlLogic.petitionId = this.data.id;
+    this._withdrawlLogic.withdrawPetition(this.data.id);
   }
 }

--- a/src/app/features/view-petition-committee/view-petition-committee.component.ts
+++ b/src/app/features/view-petition-committee/view-petition-committee.component.ts
@@ -42,8 +42,9 @@ export class ViewPetitionCommitteeComponent implements OnInit, AfterViewInit {
   ) {}
   ngAfterViewInit(): void {
     this.id = this._activatedRoute.snapshot.params['id'];
-    this._committeeLogic.petitionId =
-      this._activatedRoute.snapshot.params['id'];
+    this._committeeLogic.getPetition(
+      this._activatedRoute.snapshot.params['id']
+    );
   }
   ngOnInit(): void {
     this.result$ = this._committeeLogic.result$.subscribe((result) => {

--- a/src/app/features/view-petition-inactive/view-petition-inactive.component.ts
+++ b/src/app/features/view-petition-inactive/view-petition-inactive.component.ts
@@ -33,8 +33,9 @@ export class ViewPetitionInactiveComponent implements OnInit, AfterViewInit {
     private _activatedRoute: ActivatedRoute
   ) {}
   ngAfterViewInit(): void {
-    this._committeeLogic.petitionId =
-      this._activatedRoute.snapshot.params['id'];
+    this._committeeLogic.getPetition(
+      this._activatedRoute.snapshot.params['id']
+    );
   }
   ngOnInit(): void {
     this.result$ = this._committeeLogic.result$.subscribe((result) => {

--- a/src/app/logic/petition/edit-petition-candidate.service.ts
+++ b/src/app/logic/petition/edit-petition-candidate.service.ts
@@ -59,7 +59,7 @@ export class EditPetitionCandidateService {
     this.submit$.complete();
   }
 
-  set formGroupValue(value: CandidatePetitionData) {
+  setCandidatePetition(value: CandidatePetitionData) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/petition/edit-petition-issue.service.ts
+++ b/src/app/logic/petition/edit-petition-issue.service.ts
@@ -57,7 +57,7 @@ export class EditPetitionIssueService {
     this.submit$.complete();
   }
 
-  set formGroupValue(value: IssuePetitionData) {
+  setIssuePetition(value: IssuePetitionData) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/petition/get-petition.service.ts
+++ b/src/app/logic/petition/get-petition.service.ts
@@ -58,7 +58,7 @@ export class GetPetitionService {
     this.submit$.complete();
   }
 
-  set petitionId(value: number) {
-    this.submit$.next(value);
+  getPetition(id: number) {
+    this.submit$.next(id);
   }
 }

--- a/src/app/logic/petition/new-petition-candidate.service.ts
+++ b/src/app/logic/petition/new-petition-candidate.service.ts
@@ -57,7 +57,7 @@ export class NewPetitionCandidateService {
     this.submit$.complete();
   }
 
-  set formGroupValue(value: CandidatePetitionData) {
+  setCandidatePetition(value: CandidatePetitionData) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/petition/new-petition-issue.service.ts
+++ b/src/app/logic/petition/new-petition-issue.service.ts
@@ -57,7 +57,7 @@ export class NewPetitionIssueService {
     this.submit$.complete();
   }
 
-  set formGroupValue(value: IssuePetitionData) {
+  setIssuePetition(value: IssuePetitionData) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/petition/petition.service.ts
+++ b/src/app/logic/petition/petition.service.ts
@@ -7,6 +7,7 @@ import {
   Result,
 } from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
 
 @Injectable({ providedIn: 'root' })
 export class PetitionService {
@@ -16,6 +17,10 @@ export class PetitionService {
     data: IssuePetitionData
   ): Observable<Result<IssuePetitionData>> {
     return of({ result: data }).pipe(delay(3000));
+  }
+
+  signaturePetition(data: SignaturePetitionData): Observable<Result<string>> {
+    return of({ result: 'SUCCESS' }).pipe(delay(3000));
   }
 
   newPetitionCandidate(

--- a/src/app/logic/petition/petition.service.ts
+++ b/src/app/logic/petition/petition.service.ts
@@ -19,7 +19,7 @@ export class PetitionService {
     return of({ result: data }).pipe(delay(3000));
   }
 
-  signaturePetition(data: SignaturePetitionData): Observable<Result<string>> {
+  signPetition(data: SignaturePetitionData): Observable<Result<string>> {
     return of({ result: 'SUCCESS' }).pipe(delay(3000));
   }
 

--- a/src/app/logic/petition/sign-petition.service.spec.ts
+++ b/src/app/logic/petition/sign-petition.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SignPetitionService } from './sign-petition.service';
+
+describe('SignPetitionService', () => {
+  let service: SignPetitionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SignPetitionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/logic/petition/sign-petition.service.ts
+++ b/src/app/logic/petition/sign-petition.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+import {
+  exhaustMap,
+  map,
+  merge,
+  Observable,
+  partition,
+  shareReplay,
+  Subject,
+  tap,
+} from 'rxjs';
+import { Result } from 'src/app/shared/models/exports';
+import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
+import { PetitionService } from './petition.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SignPetitionService {
+  public error$: Observable<Result<string>>;
+  public success$: Observable<Result<string>>;
+  public loading$: Observable<boolean>;
+  public result$: Observable<Result<string>>;
+  private submit$: Subject<SignaturePetitionData> = new Subject();
+
+  constructor(private _petitionService: PetitionService) {
+    this.result$ = this.submit$.pipe(
+      exhaustMap((data) => this._petitionService.signaturePetition(data)),
+      shareReplay(1)
+    );
+    const [success$, error$] = partition(this.result$, (value) =>
+      value.result ? true : false
+    );
+
+    this.success$ = success$.pipe(
+      tap((value) => console.log(value)),
+      shareReplay(1)
+    );
+
+    this.error$ = error$.pipe(
+      tap((value) => console.log(value)),
+      shareReplay(1)
+    );
+
+    const end$ = merge(this.success$, this.error$);
+
+    this.loading$ = merge(
+      this.submit$.pipe(
+        map((v) => true),
+        tap(() => console.log('start'))
+      ),
+      end$.pipe(
+        map((v) => false),
+        tap(() => console.log('end'))
+      )
+    ).pipe(shareReplay(1));
+  }
+  ngOnDestroy(): void {
+    this.submit$.complete();
+  }
+
+  set formGroupValue(value: SignaturePetitionData) {
+    this.submit$.next(value);
+  }
+}

--- a/src/app/logic/petition/sign-petition.service.ts
+++ b/src/app/logic/petition/sign-petition.service.ts
@@ -23,7 +23,7 @@ export class SignPetitionService {
 
   constructor(private _petitionService: PetitionService) {
     this.result$ = this.submit$.pipe(
-      exhaustMap((data) => this._petitionService.signaturePetition(data)),
+      exhaustMap((data) => this._petitionService.signPetition(data)),
       shareReplay(1)
     );
     const [success$, error$] = partition(this.result$, (value) =>

--- a/src/app/logic/petition/sign-petition.service.ts
+++ b/src/app/logic/petition/sign-petition.service.ts
@@ -13,9 +13,7 @@ import { Result } from 'src/app/shared/models/exports';
 import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
 import { PetitionService } from './petition.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class SignPetitionService {
   public error$: Observable<Result<string>>;
   public success$: Observable<Result<string>>;
@@ -59,7 +57,7 @@ export class SignPetitionService {
     this.submit$.complete();
   }
 
-  set formGroupValue(value: SignaturePetitionData) {
+  setSignaturePetiton(value: SignaturePetitionData) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/petition/step-indicator.service.ts
+++ b/src/app/logic/petition/step-indicator.service.ts
@@ -15,7 +15,7 @@ export class StepIndicatorService implements OnDestroy {
   ngOnDestroy(): void {
     this._currentStep$.complete();
   }
-  set currentStep(step: 'type' | 'issue' | 'candidate' | 'result') {
+  setCurrentStep(step: 'type' | 'issue' | 'candidate' | 'result') {
     this._currentStep$.next(step);
   }
 }

--- a/src/app/logic/petition/withdraw-petition.service.ts
+++ b/src/app/logic/petition/withdraw-petition.service.ts
@@ -56,7 +56,7 @@ export class WithdrawPetitionService {
     this.submit$.complete();
   }
 
-  set petitionId(value: number) {
-    this.submit$.next(value);
+  withdrawPetition(id: number) {
+    this.submit$.next(id);
   }
 }

--- a/src/app/shared/basic-card/basic-card.component.html
+++ b/src/app/shared/basic-card/basic-card.component.html
@@ -1,5 +1,5 @@
 <div
-  class="bg-white py-8 px-6 rounded-[22px] border-solid border-1 border-gray-200 shadow-lg flex flex-col gap-[30px]"
+  class="bg-white py-8 px-6 rounded-xl md:rounded-[22px] border-solid border-1 border-gray-200 shadow-lg flex flex-col gap-[30px]"
 >
   <ng-content></ng-content>
 </div>

--- a/src/app/shared/models/petition/signature-petition-data.ts
+++ b/src/app/shared/models/petition/signature-petition-data.ts
@@ -1,0 +1,11 @@
+import { state } from 'src/app/core/states';
+import { SignaturePetitionType } from './signature-petition-type';
+
+export interface SignaturePetitionData {
+  fullName: string;
+  address: string;
+  city: string;
+  state: state;
+  zipCode: string;
+  verify?: SignaturePetitionType;
+}

--- a/src/app/shared/models/petition/signature-petition-type.ts
+++ b/src/app/shared/models/petition/signature-petition-type.ts
@@ -1,0 +1,7 @@
+import { state } from 'src/app/core/states';
+
+export interface SignaturePetitionType {
+  verifyType: string;
+  licenseNumber?: string;
+  dateOfBirth?: string;
+}

--- a/src/styles/global_cfg.scss
+++ b/src/styles/global_cfg.scss
@@ -274,7 +274,7 @@ $table-border: #d7d7d7;
 
   .mat-form-field-prefix {
     width: 50px;
-    height: 50px;
+    height: 48px;
     border-radius: 8px 0px 0px 8px;
     background-color: #ededed;
     padding: 0px !important;
@@ -385,7 +385,7 @@ $table-border: #d7d7d7;
 
   .mat-form-field-prefix {
     width: 50px;
-    height: 50px;
+    height: 48px;
     border-radius: 8px 0px 0px 8px;
     background-color: #ededed;
     padding: 0px !important;
@@ -496,7 +496,7 @@ $table-border: #d7d7d7;
 
   .mat-form-field-prefix {
     width: 50px;
-    height: 50px;
+    height: 48px;
     border-radius: 8px 0px 0px 8px;
     background-color: #ededed;
     padding: 0px !important;


### PR DESCRIPTION
Problem: Add the logic of operation to the component to sign a petition
Description: The component to sign a petition is required to be able to perform the request to sign a petition and react appropriately to the response.
Solution:
Create the petition signing service
Create a service to handle the data that is sent to the backend and transform the response that the frontend receives.

Adds the petition signing function to the petition service
Create a function in the petition service to make the call to the backend to add a signature

Integrates the petition signing service with its component
Integrates the logic of operation of the process of signing a petition to the corresponding components, the signature verification component responds correctly to the status of loading or error and redirects to the confirmation form in case of a satisfactory response