### PR TITLE
DP-171 Add a service to manage the dashboard logic

### DIFF
--- a/src/app/features/city-staff-home/city-staff-home.component.html
+++ b/src/app/features/city-staff-home/city-staff-home.component.html
@@ -11,7 +11,9 @@
     class="flex flex-col md:flex-row md:justify-between w-full gap-4 py-4 border-b-1 border-[#EDEDED]"
   >
     <dp-basic-search-engine
-      class="w-full md:max-w-[387px] min-w-[100px]"
+      (event)="search($event)"
+      [disabled]="disabledFilter"
+      class="w-full min-w-[100px]"
     ></dp-basic-search-engine>
     <dp-basic-filter
       class="w-full md:max-w-[250px] md:min-w-[150px]"
@@ -19,6 +21,7 @@
       [elements]="filterByCategory"
       [disabled]="disabledFilter"
       [mode]="'Select'"
+      (event)="filterCategory($event)"
     ></dp-basic-filter>
     <dp-basic-filter
       class="w-full md:max-w-[250px] md:min-w-[150px]"
@@ -26,6 +29,7 @@
       [elements]="filterByStatus"
       [disabled]="disabledFilter"
       [mode]="'Select'"
+      (event)="filterStatus($event)"
     ></dp-basic-filter>
   </div>
   <div class="flex p-2">
@@ -49,7 +53,8 @@
     [data]="item"
     [disabled]="disabledFilter"
     [showType]="true"
-    [showSignature]="false"
+    [showStatus]="true"
+    [showExtraDates]="true"
     [characters]="250"
     [basicRoute]="'/city-staff/home/'"
   ></dp-petition-card>
@@ -72,7 +77,7 @@
           class="w-[14px] h-[14px]"
           [svgIcon]="'custom_icons:c_close'"
         ></mat-icon>
-        <span class="ml-[9px] text-[#FF3030]"> error </span>
+        <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
       </div>
     </ng-container>
     <ng-container class="flex" *ngSwitchCase="'empty'">
@@ -81,7 +86,12 @@
       </div>
     </ng-container>
   </ng-container>
-  <button mat-button color="primary" [disabled]="disabledSeeMore">
+  <button
+    mat-button
+    color="primary"
+    (click)="pageNumber()"
+    [disabled]="disabledSeeMore"
+  >
     See More
   </button>
 </div>

--- a/src/app/shared/basic-search-engine/basic-search-engine.component.html
+++ b/src/app/shared/basic-search-engine/basic-search-engine.component.html
@@ -11,6 +11,7 @@
       type="button"
       matPrefix
       mat-icon-button
+      [disabled]="disabled"
       class="flex justify-center items-center w-full h-full"
       (click)="sendFilter()"
     >

--- a/src/app/shared/petition-card/petition-card.component.html
+++ b/src/app/shared/petition-card/petition-card.component.html
@@ -1,6 +1,6 @@
 <!--ISSUE-->
 <dp-basic-card *ngIf="data.dataIssue as issue">
-  <div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-5">
     <div class="flex flex-row justify-between">
       <div class="flex flex-row gap-[3px] items-center" *ngIf="showType">
         <mat-icon
@@ -48,8 +48,14 @@
           {{ signature.approved }} / {{ signature.required }} Signatures
           Subminted
         </p>
-      </div></ng-container
-    >
+      </div>
+    </ng-container>
+
+    <div class="flex flex-col w-full gap-2" *ngIf="showExtraDates">
+      <p class="text-sm leading-[18px]">
+        <b>Date Submitted:</b> {{ issue.createdAt }}
+      </p>
+    </div>
 
     <div *ngIf="buttonText" class="flex flex-row justify-end">
       <button
@@ -67,7 +73,7 @@
 </dp-basic-card>
 <!--CANDIDATE-->
 <dp-basic-card *ngIf="data.dataCandidate as candidate">
-  <div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-5">
     <div class="flex flex-row justify-between">
       <div class="flex flex-row gap-[3px] items-center" *ngIf="showType">
         <mat-icon
@@ -95,17 +101,21 @@
         {{ candidate.name }}
       </h3></ng-template
     >
+    <h4 class="flex leading-5 font-bold">
+      {{ candidate.office }} - {{ candidate.party }}
+    </h4>
     <p>
-      <span>Address: {{ candidate.address.address }}</span
+      <span><b>Address:</b> {{ candidate.address.address }}</span
       ><br />
       <span *ngIf="candidate.address.number as number"
-        >Number: {{ number }}</span
+        ><b>Number:</b> {{ number }}</span
       ><br />
-      <span *ngIf="candidate.address.city as city">City: {{ city }}</span
+      <span *ngIf="candidate.address.city as city"><b>City: </b>{{ city }}</span
       ><br />
-      <span>State: {{ candidate.address.state }}</span
+      <span><b>State:</b> {{ candidate.address.state }}</span
       ><br />
-      <span *ngIf="candidate.address.zipCode as code">Zip Code: {{ code }}</span
+      <span *ngIf="candidate.address.zipCode as code"
+        ><b>Zip Code:</b> {{ code }}</span
       ><br />
     </p>
     <ng-container *ngIf="candidate.signatureSummary as signature"
@@ -121,6 +131,11 @@
         </p>
       </div></ng-container
     >
+    <div class="flex flex-col w-full gap-2" *ngIf="showExtraDates">
+      <p class="text-sm leading-[18px]">
+        <b>Date Submitted:</b> {{ candidate.createdAt }}
+      </p>
+    </div>
 
     <div *ngIf="buttonText" class="flex flex-row justify-end">
       <button

--- a/src/app/shared/petition-card/petition-card.component.ts
+++ b/src/app/shared/petition-card/petition-card.component.ts
@@ -18,6 +18,7 @@ export class PetitionCardComponent implements OnInit, OnChanges {
   @Input() showType: boolean = false;
   @Input() showStatus: boolean = false;
   @Input() showSignature: boolean = false;
+  @Input() showExtraDates: boolean = false;
   @Input() characters: number = 500;
   protected showMoreOption: boolean = false;
 


### PR DESCRIPTION
Problem: Add a service to manage the dashboard logic
Description: Add the functionalities that allow the proper functioning of the dashboard and its response to one of the different states of a request to the backend.
Solution:
Add the operation logic to city-staff-home
Adds the function to request the active petitions to the backend and list them. Adds the functions of the filters and the search engine. Shows information in case of wrong responses from the backend and reacts appropriately to the state of waiting for a response.