### PR TITLE
DP-177 Add ui support to view a petition (city staff)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -159,6 +159,13 @@ const routes: Routes = [
           ),
       },
       {
+        path: 'home/:id',
+        loadChildren: () =>
+          import(
+            './features/view-petition-city-staff/view-petition-city-staff.module'
+          ).then((m) => m.ViewPetitionCityStaffModule),
+      },
+      {
         path: 'admin',
         loadChildren: () =>
           import('./city-staff/admin/admin.module').then((m) => m.AdminModule),

--- a/src/app/features/view-petition-city-staff/cualified-box/cualified-box.component.html
+++ b/src/app/features/view-petition-city-staff/cualified-box/cualified-box.component.html
@@ -1,0 +1,25 @@
+<dp-basic-card>
+  <div class="flex flex-col w-full gap-6">
+    <p class="font-bold leading-6">Petition Certification Packet</p>
+    <div class="flex flex-col w-full gap-2">
+      <button
+        class="w-full"
+        type="submit"
+        mat-flat-button
+        color="primary"
+        cdkFocusInitial
+      >
+        View Signatures
+      </button>
+      <button
+        class="w-full"
+        type="button"
+        mat-button
+        color="primary"
+        *ngIf="showDownloadPacket"
+      >
+        Download Packet
+      </button>
+    </div>
+  </div>
+</dp-basic-card>

--- a/src/app/features/view-petition-city-staff/cualified-box/cualified-box.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/cualified-box/cualified-box.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CualifiedBoxComponent } from './cualified-box.component';
+
+describe('CualifiedBoxComponent', () => {
+  let component: CualifiedBoxComponent;
+  let fixture: ComponentFixture<CualifiedBoxComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CualifiedBoxComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CualifiedBoxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/cualified-box/cualified-box.component.ts
+++ b/src/app/features/view-petition-city-staff/cualified-box/cualified-box.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'dp-cualified-box',
+  templateUrl: './cualified-box.component.html',
+})
+export class CualifiedBoxComponent implements OnInit {
+  @Input() showDownloadPacket: boolean = false;
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/features/view-petition-city-staff/cualified-box/cualified-box.module.ts
+++ b/src/app/features/view-petition-city-staff/cualified-box/cualified-box.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CualifiedBoxComponent } from './cualified-box.component';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
+import { MatButtonModule } from '@angular/material/button';
+
+@NgModule({
+  declarations: [CualifiedBoxComponent],
+  imports: [CommonModule, BasicCardModule, MatButtonModule],
+  exports: [CualifiedBoxComponent],
+})
+export class CualifiedBoxModule {}

--- a/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.component.html
+++ b/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.component.html
@@ -1,0 +1,46 @@
+<div
+  *ngIf="signatureSummary"
+  class="flex flex-col gap-4 rounded-xl p-4 bg-[#FFFFFF] border border-[#D7D7D7] shadow-sm"
+>
+  <div class="flex flex-row justify-between">
+    <p class="font-extrabold text-xl leading-7">Current Results</p>
+  </div>
+  <div class="flex flex-col w-full gap-6">
+    <p class="text-sm leading-[18px] font-bold">
+      {{
+        status === "NEW"
+          ? "N/A Signatures Submitted"
+          : signatureSummary.submitted + " / " + signatureSummary.required
+      }}
+    </p>
+    <mat-progress-bar
+      color="primary"
+      [value]="(signatureSummary.approved / signatureSummary.required) * 100"
+      [bufferValue]="signatureSummary.required"
+    ></mat-progress-bar>
+    <div class="flex flex-row w-full justify-between gap-4">
+      <p class="text-base leading-5 font-bold">Signatures Submitted</p>
+      <p class="text-base leading- font-normal">
+        {{ status === "NEW" ? "N/A" : signatureSummary.submitted }}
+      </p>
+    </div>
+    <div class="flex flex-row w-full justify-between">
+      <p class="text-base leading-5 font-bold">Signatures Verified</p>
+      <p class="text-base leading- font-normal">
+        {{ status === "NEW" ? "N/A" : signatureSummary.approved }}
+      </p>
+    </div>
+    <div class="flex flex-row w-full justify-between">
+      <p class="text-base leading-5 font-bold">Signatures Required</p>
+      <p class="text-base leading- font-normal">
+        {{ status === "NEW" ? "N/A" : signatureSummary.required }}
+      </p>
+    </div>
+    <div class="flex flex-row w-full justify-between">
+      <p class="text-base leading-5 font-bold">Petition Deadline</p>
+      <p class="text-base leading- font-normal">
+        {{ status === "NEW" ? "N/A" : signatureSummary.deadline }}
+      </p>
+    </div>
+  </div>
+</div>

--- a/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CurrentResultCityStaffComponent } from './current-result-city-staff.component';
+
+describe('CurrentResultCityStaffComponent', () => {
+  let component: CurrentResultCityStaffComponent;
+  let fixture: ComponentFixture<CurrentResultCityStaffComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CurrentResultCityStaffComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CurrentResultCityStaffComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.component.ts
+++ b/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.component.ts
@@ -1,0 +1,64 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
+import { PetitionStatus, SignatureSummary } from 'src/app/core/api/API';
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+
+@Component({
+  selector: 'dp-current-result-city-staff',
+  templateUrl: './current-result-city-staff.component.html',
+})
+export class CurrentResultCityStaffComponent implements OnInit, OnChanges {
+  @Input() data: ResponsePetition = {};
+
+  protected status: PetitionStatus | undefined;
+  protected signatureSummary: SignatureSummary | null | undefined;
+
+  protected StatusStyleCurrent: string = '';
+  protected StatusStyleWhite: string =
+    'h-[26px] bg-[#F8F8F8] px-4 py-1 text-[#5C5C5C]  rounded';
+  protected StatusStyleGreen: string =
+    'h-[26px] bg-[#3AC922] px-4 py-1 text-black  rounded';
+  protected StatusStyleRed: string =
+    'h-[26px] bg-[#FF3030] px-4 py-1 text-black  rounded';
+
+  constructor() {}
+  ngOnChanges(changes: SimpleChanges): void {
+    let { status } = this.data.dataCandidate
+      ? this.data.dataCandidate
+      : this.data.dataIssue
+      ? this.data.dataIssue
+      : { status: undefined };
+    this.status = status;
+
+    let { signatureSummary } = this.data.dataCandidate
+      ? this.data.dataCandidate
+      : this.data.dataIssue
+      ? this.data.dataIssue
+      : { signatureSummary: undefined };
+    this.signatureSummary = signatureSummary;
+
+    if (status) {
+      switch (status) {
+        case PetitionStatus.NEW:
+          this.StatusStyleCurrent = this.StatusStyleWhite;
+          break;
+        case PetitionStatus.QUALIFIED:
+          this.StatusStyleCurrent = this.StatusStyleGreen;
+          break;
+        case PetitionStatus.REJECTED:
+          this.StatusStyleCurrent = this.StatusStyleRed;
+          break;
+        case PetitionStatus.ACTIVE:
+          this.StatusStyleCurrent = '';
+          break;
+      }
+    }
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.module.ts
+++ b/src/app/features/view-petition-city-staff/current-result-city-staff/current-result-city-staff.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CurrentResultCityStaffComponent } from './current-result-city-staff.component';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+@NgModule({
+  declarations: [CurrentResultCityStaffComponent],
+  imports: [CommonModule, MatProgressBarModule],
+  exports: [CurrentResultCityStaffComponent],
+})
+export class CurrentResultCityStaffModule {}

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.html
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.html
@@ -1,0 +1,12 @@
+<div class="flex flex-col w-full gap-2">
+  <button
+    class="w-full"
+    type="submit"
+    mat-flat-button
+    color="primary"
+    cdkFocusInitial
+  >
+    Aprove
+  </button>
+  <button class="w-full" type="button" mat-button color="primary">Deny</button>
+</div>

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewBoxComponent } from './new-box.component';
+
+describe('NewBoxComponent', () => {
+  let component: NewBoxComponent;
+  let fixture: ComponentFixture<NewBoxComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ NewBoxComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(NewBoxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.ts
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'dp-new-box',
+  templateUrl: './new-box.component.html',
+})
+export class NewBoxComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/features/view-petition-city-staff/new-box/new-box.module.ts
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NewBoxComponent } from './new-box.component';
+import { MatButtonModule } from '@angular/material/button';
+
+@NgModule({
+  declarations: [NewBoxComponent],
+  imports: [CommonModule, MatButtonModule],
+  exports: [NewBoxComponent],
+})
+export class NewBoxModule {}

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff-routing.module.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ViewPetitionCityStaffComponent } from './view-petition-city-staff.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ViewPetitionCityStaffComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ViewPetitionCityStaffRoutingModule {}

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
@@ -1,0 +1,35 @@
+<div class="flex justify-center w-full py-12">
+  <div class="flex flex-col max-w-[1197px] w-full gap-4">
+    <div class="flex w-fit">
+      <dp-return-link
+        [route]="'/city-staff/home'"
+        [text]="'Back to Petition List'"
+      ></dp-return-link>
+    </div>
+
+    <div class="flex flex-col-reverse md:flex-row justify-center gap-6 mt-4">
+      <div class="flex flex-col gap-5 max-w-[791px] w-full">
+        <dp-petition-view
+          [data]="resultData"
+          [showStatus]="true"
+        ></dp-petition-view>
+      </div>
+      <div class="flex flex-col max-w-[386px] w-full h-fit gap-[11px]">
+        <dp-current-result-city-staff
+          [data]="resultData"
+        ></dp-current-result-city-staff>
+        <ng-container [ngSwitch]="petition?.status">
+          <ng-container class="flex" *ngSwitchCase="'NEW'">
+            <dp-new-box></dp-new-box>
+          </ng-container>
+          <ng-container class="flex" *ngSwitchCase="'QUALIFIED'">
+            <dp-cualified-box [showDownloadPacket]="true"></dp-cualified-box>
+          </ng-container>
+          <ng-container class="flex" *ngSwitchCase="'CANCELED'">
+            <dp-cualified-box></dp-cualified-box>
+          </ng-container>
+        </ng-container>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewPetitionCityStaffComponent } from './view-petition-city-staff.component';
+
+describe('ViewPetitionCityStaffComponent', () => {
+  let component: ViewPetitionCityStaffComponent;
+  let fixture: ComponentFixture<ViewPetitionCityStaffComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewPetitionCityStaffComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ViewPetitionCityStaffComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core';
+
+import {
+  CandidatePetition,
+  IssuePetition,
+  PetitionStatus,
+  PetitionType,
+} from 'src/app/core/api/API';
+
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+
+@Component({
+  selector: 'dp-view-petition-city-staff',
+  templateUrl: './view-petition-city-staff.component.html',
+})
+export class ViewPetitionCityStaffComponent implements OnInit {
+  private IssuePetition: 'IssuePetition' = 'IssuePetition';
+  private CandidatePetition: 'CandidatePetition' = 'CandidatePetition';
+  private AddressData: 'AddressData' = 'AddressData';
+  private SignatureSummary: 'SignatureSummary' = 'SignatureSummary';
+  protected resultData: ResponsePetition = {
+    dataIssue: {
+      __typename: this.IssuePetition,
+      PK: '0',
+      createdAt: '00/00/0000',
+      detail:
+        'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto!',
+      owner: 'CommitteUser-1',
+      signatureSummary: {
+        __typename: this.SignatureSummary,
+        approved: 15000,
+        deadline: '00/00/0000',
+        required: 24000,
+        submitted: 20000,
+      },
+      status: PetitionStatus.NEW,
+      title: 'Title1',
+      type: PetitionType.ISSUE,
+    },
+  };
+
+  protected petition: IssuePetition | CandidatePetition | undefined;
+  constructor() {}
+
+  ngOnInit(): void {
+    this.setState();
+  }
+  private setState() {
+    this.petition = this.resultData.dataCandidate
+      ? this.resultData.dataCandidate
+      : this.resultData.dataIssue
+      ? this.resultData.dataIssue
+      : undefined;
+  }
+  submit() {}
+}

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.module.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.module.ts
@@ -1,0 +1,31 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ViewPetitionCityStaffComponent } from './view-petition-city-staff.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { PetitionViewModule } from 'src/app/shared/petition-view/petition-view.module';
+import { CurrentResultCityStaffModule } from './current-result-city-staff/current-result-city-staff.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { RouterModule } from '@angular/router';
+import { ViewPetitionCityStaffRoutingModule } from './view-petition-city-staff-routing.module';
+import { GetPetitionService } from 'src/app/logic/petition/get-petition.service';
+import { NewBoxModule } from './new-box/new-box.module';
+import { CualifiedBoxModule } from './cualified-box/cualified-box.module';
+
+@NgModule({
+  declarations: [ViewPetitionCityStaffComponent],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatProgressBarModule,
+    PetitionViewModule,
+    CurrentResultCityStaffModule,
+    ReturnLinkModule,
+    RouterModule,
+    ViewPetitionCityStaffRoutingModule,
+    NewBoxModule,
+    CualifiedBoxModule,
+  ],
+  providers: [GetPetitionService],
+})
+export class ViewPetitionCityStaffModule {}

--- a/src/app/features/view-petition-inactive/status/status.component.html
+++ b/src/app/features/view-petition-inactive/status/status.component.html
@@ -22,7 +22,7 @@
     ></mat-progress-bar>
     <p class="text-[14px] leading-[18px] font-normal">
       {{ petition.signatureSummary.approved }} /
-      {{ petition.signatureSummary.required }} Signatures Subminted
+      {{ petition.signatureSummary.required }} Signatures Submitted
     </p>
   </div>
 </div>

--- a/src/app/pipes/petition-status/petition-status.module.ts
+++ b/src/app/pipes/petition-status/petition-status.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PetitionStatusPipe } from './petition-status.pipe';
+
+@NgModule({
+  declarations: [PetitionStatusPipe],
+  imports: [CommonModule],
+  exports: [PetitionStatusPipe],
+})
+export class PetitionStatusModule {}

--- a/src/app/pipes/petition-status/petition-status.pipe.spec.ts
+++ b/src/app/pipes/petition-status/petition-status.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { PetitionStatusPipe } from './petition-status.pipe';
+
+describe('PetitionStatusPipe', () => {
+  it('create an instance', () => {
+    const pipe = new PetitionStatusPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/petition-status/petition-status.pipe.ts
+++ b/src/app/pipes/petition-status/petition-status.pipe.ts
@@ -1,0 +1,32 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { PetitionStatus } from 'src/app/core/api/API';
+
+@Pipe({
+  name: 'petitionStatus',
+})
+export class PetitionStatusPipe implements PipeTransform {
+  transform(value: string, ...args: unknown[]): string {
+    switch (value) {
+      case PetitionStatus.ACTIVE:
+        return 'Active';
+        break;
+      case PetitionStatus.CANCELED:
+        return 'Canceled';
+        break;
+      case PetitionStatus.NEW:
+        return 'Awaiting approval';
+        break;
+      case PetitionStatus.QUALIFIED:
+        return 'Qualified';
+        break;
+      case PetitionStatus.REJECTED:
+        return 'Rejected';
+        break;
+      case PetitionStatus.WITHDRAWN:
+        return 'Withdrawn';
+        break;
+      default:
+        return '';
+    }
+  }
+}

--- a/src/app/pipes/petition-type/petition-type.module.ts
+++ b/src/app/pipes/petition-type/petition-type.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PetitionTypePipe } from './petition-type.pipe';
+
+@NgModule({
+  declarations: [PetitionTypePipe],
+  imports: [CommonModule],
+  exports: [PetitionTypePipe],
+})
+export class PetitionTypeModule {}

--- a/src/app/pipes/petition-type/petition-type.pipe.spec.ts
+++ b/src/app/pipes/petition-type/petition-type.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { PetitionTypePipe } from './petition-type.pipe';
+
+describe('PetitionTypePipe', () => {
+  it('create an instance', () => {
+    const pipe = new PetitionTypePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/petition-type/petition-type.pipe.ts
+++ b/src/app/pipes/petition-type/petition-type.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { PetitionType } from 'src/app/core/api/API';
+
+@Pipe({
+  name: 'petitionType',
+})
+export class PetitionTypePipe implements PipeTransform {
+  transform(value: string, ...args: unknown[]): string {
+    return value === PetitionType.CANDIDATE ? 'Candidate' : 'Issue';
+  }
+}

--- a/src/app/shared/petition-card/petition-card.component.html
+++ b/src/app/shared/petition-card/petition-card.component.html
@@ -8,12 +8,12 @@
           [svgIcon]="'custom_icons:bullet'"
         ></mat-icon>
         <p class="text-[#5C5C5C] font-normal text-sm leading-[14px]">
-          {{ issue.type }}
+          {{ issue.type | petitionType }}
         </p>
       </div>
       <div [class]="StatusStyleCurrent" *ngIf="showStatus">
         <p class="font-normal text-sm leading-[18px]">
-          {{ issue.status }}
+          {{ issue.status | petitionStatus }}
         </p>
       </div>
     </div>
@@ -81,12 +81,12 @@
           [svgIcon]="'custom_icons:bullet'"
         ></mat-icon>
         <p class="text-[#5C5C5C] font-normal text-sm leading-[14px]">
-          {{ candidate.type }}
+          {{ candidate.type | petitionType }}
         </p>
       </div>
       <div [class]="StatusStyleCurrent" *ngIf="showStatus">
         <p class="font-normal text-sm leading-[18px]">
-          {{ candidate.status }}
+          {{ candidate.status | petitionStatus }}
         </p>
       </div>
     </div>

--- a/src/app/shared/petition-card/petition-card.module.ts
+++ b/src/app/shared/petition-card/petition-card.module.ts
@@ -7,6 +7,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { CutModule } from 'src/app/pipes/cut/cut.module';
 import { RouterModule } from '@angular/router';
+import { PetitionTypeModule } from 'src/app/pipes/petition-type/petition-type.module';
+import { PetitionStatusModule } from 'src/app/pipes/petition-status/petition-status.module';
 
 @NgModule({
   declarations: [PetitionCardComponent],
@@ -18,6 +20,8 @@ import { RouterModule } from '@angular/router';
     MatProgressBarModule,
     CutModule,
     RouterModule,
+    PetitionTypeModule,
+    PetitionStatusModule,
   ],
   exports: [PetitionCardComponent],
 })

--- a/src/app/shared/petition-view/petition-view.component.html
+++ b/src/app/shared/petition-view/petition-view.component.html
@@ -1,5 +1,8 @@
 <dp-basic-card *ngIf="data.dataIssue as issue">
-  <div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-5">
+    <div *ngIf="showStatus" [class]="StatusStyleCurrent">
+      <p>{{ issue.status | petitionStatus }}</p>
+    </div>
     <h3 class="flex leading-7 font-extrabold">{{ issue.title }}</h3>
     <div class="flex flex-row justify-between">
       <div class="flex flex-row gap-[3px] items-center">
@@ -8,7 +11,7 @@
           [svgIcon]="'custom_icons:bullet'"
         ></mat-icon>
         <p class="text-[#5C5C5C] font-normal text-sm leading-[14px]">
-          {{ issue.type }}
+          {{ issue.type | petitionType }}
         </p>
       </div>
     </div>
@@ -18,7 +21,10 @@
   </div>
 </dp-basic-card>
 <dp-basic-card *ngIf="data.dataCandidate as candidate">
-  <div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-5">
+    <div *ngIf="showStatus" [class]="StatusStyleCurrent">
+      <p>{{ candidate.status | petitionStatus }}</p>
+    </div>
     <h3 class="flex leading-7 font-extrabold">{{ candidate.name }}</h3>
     <h4 class="leading-5 font-bold">
       {{ candidate.office + " - " + candidate.party }}
@@ -30,7 +36,7 @@
           [svgIcon]="'custom_icons:bullet'"
         ></mat-icon>
         <p class="text-[#5C5C5C] font-normal text-sm leading-[14px]">
-          {{ candidate.type }}
+          {{ candidate.type | petitionType }}
         </p>
       </div>
     </div>

--- a/src/app/shared/petition-view/petition-view.component.ts
+++ b/src/app/shared/petition-view/petition-view.component.ts
@@ -5,6 +5,11 @@ import {
   OnInit,
   SimpleChanges,
 } from '@angular/core';
+import {
+  CandidatePetition,
+  IssuePetition,
+  PetitionStatus,
+} from 'src/app/core/api/API';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 
 @Component({
@@ -13,9 +18,37 @@ import { ResponsePetition } from 'src/app/shared/models/petition/response-petiti
 })
 export class PetitionViewComponent implements OnInit, OnChanges {
   @Input() data: ResponsePetition = {};
-
+  @Input() showStatus: boolean = false;
+  protected petition: IssuePetition | CandidatePetition | undefined;
+  protected StatusStyleCurrent: string = '';
+  protected StatusStyleYellow: string =
+    'flex bg-[#F6D523] px-2 py-1 rounded-full items-center justify-center w-fit';
+  protected StatusStyleGreen: string =
+    'flex bg-[#3AC922] px-2 py-1 rounded-full items-center justify-center w-fit';
+  protected StatusStyleGray: string =
+    'flex bg-[#8A8A8A] px-2 py-1 rounded-full items-center justify-center w-fit';
   constructor() {}
-  ngOnChanges(changes: SimpleChanges): void {}
+  ngOnChanges(changes: SimpleChanges): void {
+    this.petition = this.data.dataCandidate
+      ? this.data.dataCandidate
+      : this.data.dataIssue
+      ? this.data.dataIssue
+      : undefined;
+
+    if (this.petition) {
+      switch (this.petition.status) {
+        case PetitionStatus.NEW:
+          this.StatusStyleCurrent = this.StatusStyleYellow;
+          break;
+        case PetitionStatus.QUALIFIED:
+          this.StatusStyleCurrent = this.StatusStyleGreen;
+          break;
+        case PetitionStatus.CANCELED:
+          this.StatusStyleCurrent = this.StatusStyleGray;
+          break;
+      }
+    }
+  }
 
   ngOnInit(): void {}
 }

--- a/src/app/shared/petition-view/petition-view.module.ts
+++ b/src/app/shared/petition-view/petition-view.module.ts
@@ -6,6 +6,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { CutModule } from 'src/app/pipes/cut/cut.module';
+import { PetitionTypeModule } from 'src/app/pipes/petition-type/petition-type.module';
+import { PetitionStatusModule } from 'src/app/pipes/petition-status/petition-status.module';
 
 @NgModule({
   declarations: [PetitionViewComponent],
@@ -16,6 +18,8 @@ import { CutModule } from 'src/app/pipes/cut/cut.module';
     MatButtonModule,
     MatProgressBarModule,
     CutModule,
+    PetitionTypeModule,
+    PetitionStatusModule,
   ],
   exports: [PetitionViewComponent],
 })


### PR DESCRIPTION
Problem: Add UI support to view a petition (City Staff)
Description: Create the interface to support the function of seeing a petition from the city staff. The view should show different actions according to the state of the petition 
Solution:
Create a pipe to transform the type of petition:
Create a pipe to convert the value of the TypeRequest type object into a text corresponding to the design

Create a pipe to transform the status of petition:
Create a pipe to convert the value of the object type StatusPetition into a text corresponding to the design

Add petition status to the petition-view component:
An optional element to display the status of the petition is added to the view-petition component. The TypePetitionPipe and StatusPetitionPipe pipes are also added.

Add petition-type and petition-status pipes to petition-card:

Create a component to display qualified petition actions

Create a component to display AwaitingApproval petition actions

Create a component to display petition signature results

Create the view-petition-city-staff component

Add a route to display request details (city-staff)