### PR TITLE
DP-178 Add a service to manage viewa a petition

### DIFF
--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
@@ -7,29 +7,61 @@
       ></dp-return-link>
     </div>
 
-    <div class="flex flex-col-reverse md:flex-row justify-center gap-6 mt-4">
-      <div class="flex flex-col gap-5 max-w-[791px] w-full">
-        <dp-petition-view
-          [data]="resultData"
-          [showStatus]="true"
-        ></dp-petition-view>
-      </div>
-      <div class="flex flex-col max-w-[386px] w-full h-fit gap-[11px]">
-        <dp-current-result-city-staff
-          [data]="resultData"
-        ></dp-current-result-city-staff>
-        <ng-container [ngSwitch]="petition?.status">
-          <ng-container class="flex" *ngSwitchCase="'NEW'">
-            <dp-new-box></dp-new-box>
-          </ng-container>
-          <ng-container class="flex" *ngSwitchCase="'QUALIFIED'">
-            <dp-cualified-box [showDownloadPacket]="true"></dp-cualified-box>
-          </ng-container>
-          <ng-container class="flex" *ngSwitchCase="'CANCELED'">
-            <dp-cualified-box></dp-cualified-box>
-          </ng-container>
-        </ng-container>
-      </div>
-    </div>
+    <ng-container [ngSwitch]="currentStep$ | async">
+      <ng-container *ngSwitchCase="'loading'">
+        <div class="flex justify-center w-full">
+          <h3 class="leading-7 font-extrabold">Loading</h3>
+        </div>
+
+        <mat-progress-bar
+          mode="indeterminate"
+          color="primary"
+        ></mat-progress-bar>
+      </ng-container>
+      <ng-container class="flex" *ngSwitchCase="'error'">
+        <div class="flex justify-center w-full">
+          <h3 class="leading-7 font-extrabold">An error has occurred</h3>
+        </div>
+
+        <div class="flex flex-row items-center justify-center">
+          <mat-icon
+            class="w-[14px] h-[14px]"
+            [svgIcon]="'custom_icons:c_close'"
+          ></mat-icon>
+          <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
+        </div>
+      </ng-container>
+
+      <ng-container class="flex" *ngSwitchCase="'contents'">
+        <div
+          class="flex flex-col-reverse md:flex-row justify-center gap-6 mt-4"
+        >
+          <div class="flex flex-col gap-5 max-w-[791px] w-full">
+            <dp-petition-view
+              [data]="resultData"
+              [showStatus]="true"
+            ></dp-petition-view>
+          </div>
+          <div class="flex flex-col max-w-[386px] w-full h-fit gap-[11px]">
+            <dp-current-result-city-staff
+              [data]="resultData"
+            ></dp-current-result-city-staff>
+            <ng-container [ngSwitch]="petition?.status">
+              <ng-container class="flex" *ngSwitchCase="'NEW'">
+                <dp-new-box></dp-new-box>
+              </ng-container>
+              <ng-container class="flex" *ngSwitchCase="'QUALIFIED'">
+                <dp-cualified-box
+                  [showDownloadPacket]="true"
+                ></dp-cualified-box>
+              </ng-container>
+              <ng-container class="flex" *ngSwitchCase="'CANCELED'">
+                <dp-cualified-box></dp-cualified-box>
+              </ng-container>
+            </ng-container>
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
   </div>
 </div>

--- a/src/app/logic/petition/petition.service.ts
+++ b/src/app/logic/petition/petition.service.ts
@@ -82,26 +82,26 @@ export class PetitionService {
   getPetition(data: number): Observable<Result<ResponsePetition>> {
     return of({
       result: {
-        /**
-          dataIssue: {
-            __typename: this.IssuePetition,
-            PK: '0',
-            createdAt: '00/00/0000',
-            detail:
-              'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto!',
-            owner: 'CommitteUser-1',
-            signatureSummary: {
-              __typename: this.SignatureSummary,
-              approved: 15000,
-              deadline: '00/00/0000',
-              required: 24000,
-              submitted: 20000,
-            },
-            status: PetitionStatus.ACTIVE,
-            title: 'Title1',
-            type: PetitionType.ISSUE,
+        dataIssue: {
+          __typename: this.IssuePetition,
+          PK: '0',
+          createdAt: '00/00/0000',
+          detail:
+            'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto! Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas fugiat dicta omnis nulla nam, reprehenderit officia quo sit a recusandae animi maxime odit qui voluptatum, eaque quod dolorum non iusto!',
+          owner: 'CommitteUser-1',
+          signatureSummary: {
+            __typename: this.SignatureSummary,
+            approved: 15000,
+            deadline: '00/00/0000',
+            required: 24000,
+            submitted: 20000,
           },
-        */
+          status: PetitionStatus.NEW,
+          title: 'Title1',
+          type: PetitionType.ISSUE,
+        },
+
+        /** 
         dataCandidate: {
           __typename: this.CandidatePetition,
           PK: '0',
@@ -126,10 +126,11 @@ export class PetitionService {
           },
           status: PetitionStatus.ACTIVE,
           name: 'First name and last name',
-          type: PetitionType.ISSUE,
+          type: PetitionType.CANDIDATE,
         },
+        */
       },
-    }).pipe(delay(3000));
+    }).pipe(delay(1000));
   }
 
   withdrawPetition(data: number): Observable<Result<string>> {


### PR DESCRIPTION
Problem: Add a service to manage view on petition
Description: Add the operation logic of the view-petition-city-staff component and link it to the petition request service
Solution:
Add the operation logic to view-petition-city-staff
Elements to display loading and error states are added to the layout. Logic is added that allows the component to respond appropriately to a successful or failed response as well as to the waiting state. The component is linked to the petition request service.