### PR TITLE
DP-173 Add ui support to approve a petition city staff

### DIFF
--- a/src/app/features/view-petition-city-staff/approve-alert/approve-alert.component.html
+++ b/src/app/features/view-petition-city-staff/approve-alert/approve-alert.component.html
@@ -1,0 +1,26 @@
+<dp-basic-alert (event)="submit()">
+  <span modal-title>Do you want to approve this petition?</span>
+  <span modal-body class="w-full flex flex-col gap-6">
+    <div class="flex flex-col w-full gap-4">
+      <button
+        mat-flat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="primary"
+        [mat-dialog-close]="true"
+      >
+        Approve
+      </button>
+      <button
+        mat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="primary"
+        cdkFocusInitial
+        [mat-dialog-close]="false"
+      >
+        Cancel
+      </button>
+    </div>
+  </span>
+</dp-basic-alert>

--- a/src/app/features/view-petition-city-staff/approve-alert/approve-alert.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/approve-alert/approve-alert.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ApproveAlertComponent } from './approve-alert.component';
+
+describe('AproveAlertComponent', () => {
+  let component: ApproveAlertComponent;
+  let fixture: ComponentFixture<ApproveAlertComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ApproveAlertComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApproveAlertComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/approve-alert/approve-alert.component.ts
+++ b/src/app/features/view-petition-city-staff/approve-alert/approve-alert.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'dp-aprove-alert',
+  templateUrl: './approve-alert.component.html',
+})
+export class ApproveAlertComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  submit() {
+    console.log('asdasd');
+  }
+}

--- a/src/app/features/view-petition-city-staff/approve-alert/approve-alert.module.ts
+++ b/src/app/features/view-petition-city-staff/approve-alert/approve-alert.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApproveAlertComponent } from './approve-alert.component';
+import { BasicAlertModule } from 'src/app/shared/basic-alert/basic-alert.module';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@NgModule({
+  declarations: [ApproveAlertComponent],
+  imports: [CommonModule, BasicAlertModule, MatDialogModule, MatButtonModule],
+  exports: [ApproveAlertComponent],
+})
+export class ApproveAlertModule {}

--- a/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.html
+++ b/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.html
@@ -1,0 +1,38 @@
+<dp-basic-modal (event)="submit()">
+  <ng-container modal-title>Set Qualification Requirements</ng-container>
+  <ng-container modal-body class="w-full">
+    <form [formGroup]="formGroup" class="flex flex-col w-full gap-6">
+      <mat-form-field class="w-full">
+        <mat-label>Set Deadline</mat-label>
+        <input matInput [matDatepicker]="picker" formControlName="deadline" />
+        <mat-datepicker-toggle matPrefix [for]="picker"></mat-datepicker-toggle>
+        <mat-datepicker #picker></mat-datepicker>
+        <mat-error *ngIf="this.formGroup.get('deadline')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">Set Deadline is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="w-full">
+        <mat-label>Enter number of Signatures Required</mat-label>
+        <input type="text" matInput formControlName="signatures" />
+        <mat-error
+          *ngIf="this.formGroup.get('signatures')?.errors?.['required']"
+        >
+          <div class="flex flex-row items-center">
+            <mat-icon
+              class="w-[14px] h-[14px]"
+              [svgIcon]="'custom_icons:c_close'"
+            ></mat-icon>
+            <span class="ml-[9px]">Number of signatures is required</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+    </form>
+  </ng-container>
+  <ng-container modal-footer>Continue</ng-container>
+</dp-basic-modal>

--- a/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ApproveDialogComponent } from './approve-dialog.component';
+
+describe('AproveDialogComponent', () => {
+  let component: ApproveDialogComponent;
+  let fixture: ComponentFixture<ApproveDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ApproveDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApproveDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.ts
+++ b/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogResultComponent } from 'src/app/shared/dialog-result/dialog-result.component';
+import { ApproveAlertComponent } from '../approve-alert/approve-alert.component';
+
+@Component({
+  selector: 'dp-aprove-dialog',
+  templateUrl: './approve-dialog.component.html',
+})
+export class ApproveDialogComponent implements OnInit {
+  protected formGroup: FormGroup;
+  constructor(public _dialog: MatDialog, private _fb: FormBuilder) {
+    this.formGroup = this._fb.group({
+      deadline: ['', [Validators.required]],
+      signatures: ['', [Validators.required]],
+    });
+  }
+
+  ngOnInit(): void {}
+
+  submit() {
+    if (this.formGroup.valid) {
+      const dialogRef = this._dialog.open(ApproveAlertComponent, {
+        width: '480px',
+      });
+
+      dialogRef.afterClosed().subscribe((result) => {
+        if (result) {
+          console.log(this.formGroup.value);
+          this._dialog.open(DialogResultComponent, {
+            width: '520px',
+            data: {
+              title: 'Petition Approved!',
+              message: '',
+              success: true,
+            },
+          });
+        } else {
+          this._dialog.closeAll();
+        }
+      });
+    } else {
+      this.formGroup.markAllAsTouched();
+    }
+  }
+}

--- a/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.module.ts
+++ b/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.module.ts
@@ -1,0 +1,33 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApproveDialogComponent } from './approve-dialog.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BasicModalModule } from 'src/app/shared/basic-modal/basic-modal.module';
+import { MatDialogModule } from '@angular/material/dialog';
+import { ApproveAlertModule } from '../approve-alert/approve-alert.module';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { DialogResultModule } from 'src/app/shared/dialog-result/dialog-result.module';
+
+@NgModule({
+  declarations: [ApproveDialogComponent],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatInputModule,
+    FormsModule,
+    ReactiveFormsModule,
+    BasicModalModule,
+    MatDialogModule,
+    ApproveAlertModule,
+    MatIconModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    DialogResultModule,
+  ],
+  exports: [ApproveDialogComponent],
+})
+export class ApproveDialogModule {}

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.html
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.html
@@ -5,6 +5,7 @@
     mat-flat-button
     color="primary"
     cdkFocusInitial
+    (click)="aproveEvent.emit()"
   >
     Aprove
   </button>

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.ts
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'dp-new-box',
   templateUrl: './new-box.component.html',
 })
 export class NewBoxComponent implements OnInit {
+  @Output() aproveEvent: EventEmitter<void> = new EventEmitter();
+
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
@@ -48,7 +48,7 @@
             ></dp-current-result-city-staff>
             <ng-container [ngSwitch]="petition?.status">
               <ng-container class="flex" *ngSwitchCase="'NEW'">
-                <dp-new-box></dp-new-box>
+                <dp-new-box (aproveEvent)="aproveDialog()"></dp-new-box>
               </ng-container>
               <ng-container class="flex" *ngSwitchCase="'QUALIFIED'">
                 <dp-cualified-box

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.ts
@@ -11,6 +11,7 @@ import { GetPetitionService } from 'src/app/logic/petition/get-petition.service'
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 import { AlertWithdrawlPetitionComponent } from '../view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component';
 import { ConfirmWithdrawlPetitionComponent } from '../view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component';
+import { ApproveDialogComponent } from './approve-dialog/approve-dialog.component';
 
 @Component({
   selector: 'dp-view-petition-city-staff',
@@ -31,11 +32,8 @@ export class ViewPetitionCityStaffComponent implements OnInit {
   protected petition: IssuePetition | CandidatePetition | undefined;
   constructor(
     private _committeeLogic: GetPetitionService,
-
-    private _activatedRoute: ActivatedRoute,
-    public _alertDialogRef: MatDialogRef<AlertWithdrawlPetitionComponent>,
-    public _confirmDalogRef: MatDialogRef<ConfirmWithdrawlPetitionComponent>,
-    public _dialog: MatDialog
+    private _dialog: MatDialog,
+    private _activatedRoute: ActivatedRoute
   ) {}
   ngAfterViewInit(): void {
     this.id = this._activatedRoute.snapshot.params['id'];
@@ -63,5 +61,14 @@ export class ViewPetitionCityStaffComponent implements OnInit {
       ? this.resultData.dataIssue
       : undefined;
   }
-  submit() {}
+
+  aproveDialog(): void {
+    const dialogRef = this._dialog.open(ApproveDialogComponent, {
+      width: '690px',
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      console.log('The dialog was closed ' + result);
+    });
+  }
 }

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.module.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.module.ts
@@ -11,6 +11,7 @@ import { ViewPetitionCityStaffRoutingModule } from './view-petition-city-staff-r
 import { GetPetitionService } from 'src/app/logic/petition/get-petition.service';
 import { NewBoxModule } from './new-box/new-box.module';
 import { CualifiedBoxModule } from './cualified-box/cualified-box.module';
+import { ApproveDialogModule } from './approve-dialog/approve-dialog.module';
 
 @NgModule({
   declarations: [ViewPetitionCityStaffComponent],
@@ -25,6 +26,7 @@ import { CualifiedBoxModule } from './cualified-box/cualified-box.module';
     ViewPetitionCityStaffRoutingModule,
     NewBoxModule,
     CualifiedBoxModule,
+    ApproveDialogModule,
   ],
   providers: [GetPetitionService],
 })

--- a/src/app/shared/dialog-result/dialog-result.component.html
+++ b/src/app/shared/dialog-result/dialog-result.component.html
@@ -11,7 +11,7 @@
     </h4>
   </div>
 
-  <p class="w-full justify-center text-center">
+  <p *ngIf="data.message != ''" class="w-full justify-center text-center">
     {{ data.message }}
   </p>
   <div class="w-full flex justify-center">


### PR DESCRIPTION
Problem: Add UI support to approve a request (City Staff)
Description: Provide interface support for the approval process of a petition by a user of the city staff.
Solution:
Create the approve-dialog component
Form to retrieve the deadline data and signatures required for a petition

Create the approve-alert component

Add the call to the function to approve a petition

Fix a bug when displaying the content in dialog-result