### PR TITLE
DP-174 Add ui support to reject a petition city staff

### DIFF
--- a/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.html
+++ b/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.html
@@ -1,0 +1,1 @@
+<p>deny-alert works!</p>

--- a/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.html
+++ b/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.html
@@ -1,1 +1,28 @@
-<p>deny-alert works!</p>
+<dp-basic-alert>
+  <ng-container modal-title
+    >Are you sure you want to deny this petition?</ng-container
+  >
+  <ng-container modal-body class="w-full flex flex-col gap-6">
+    <div class="flex flex-col w-full gap-4">
+      <button
+        mat-flat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="warn"
+        [mat-dialog-close]="true"
+      >
+        Deny petition
+      </button>
+      <button
+        mat-button
+        type="button"
+        class="h-10 w-full mt-2"
+        color="primary"
+        cdkFocusInitial
+        [mat-dialog-close]="false"
+      >
+        Cancel
+      </button>
+    </div>
+  </ng-container>
+</dp-basic-alert>

--- a/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.spec.ts
+++ b/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DenyAlertComponent } from './deny-alert.component';
+
+describe('DenyAlertComponent', () => {
+  let component: DenyAlertComponent;
+  let fixture: ComponentFixture<DenyAlertComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DenyAlertComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DenyAlertComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.ts
+++ b/src/app/features/view-petition-city-staff/deny-alert/deny-alert.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'dp-deny-alert',
+  templateUrl: './deny-alert.component.html',
+})
+export class DenyAlertComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/features/view-petition-city-staff/deny-alert/deny-alert.module.ts
+++ b/src/app/features/view-petition-city-staff/deny-alert/deny-alert.module.ts
@@ -1,15 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DenyAlertComponent } from './deny-alert.component';
-
-
+import { MatDialogModule } from '@angular/material/dialog';
+import { BasicAlertModule } from 'src/app/shared/basic-alert/basic-alert.module';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
-  declarations: [
-    DenyAlertComponent
-  ],
-  imports: [
-    CommonModule
-  ]
+  declarations: [DenyAlertComponent],
+  imports: [CommonModule, MatDialogModule, BasicAlertModule, MatButtonModule],
+  exports: [DenyAlertComponent],
 })
-export class DenyAlertModule { }
+export class DenyAlertModule {}

--- a/src/app/features/view-petition-city-staff/deny-alert/deny-alert.module.ts
+++ b/src/app/features/view-petition-city-staff/deny-alert/deny-alert.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DenyAlertComponent } from './deny-alert.component';
+
+
+
+@NgModule({
+  declarations: [
+    DenyAlertComponent
+  ],
+  imports: [
+    CommonModule
+  ]
+})
+export class DenyAlertModule { }

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.html
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.html
@@ -5,9 +5,17 @@
     mat-flat-button
     color="primary"
     cdkFocusInitial
-    (click)="aproveEvent.emit()"
+    (click)="approveEvent.emit()"
   >
     Aprove
   </button>
-  <button class="w-full" type="button" mat-button color="primary">Deny</button>
+  <button
+    class="w-full"
+    type="button"
+    mat-button
+    color="primary"
+    (click)="denyEvent.emit()"
+  >
+    Deny
+  </button>
 </div>

--- a/src/app/features/view-petition-city-staff/new-box/new-box.component.ts
+++ b/src/app/features/view-petition-city-staff/new-box/new-box.component.ts
@@ -5,7 +5,8 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
   templateUrl: './new-box.component.html',
 })
 export class NewBoxComponent implements OnInit {
-  @Output() aproveEvent: EventEmitter<void> = new EventEmitter();
+  @Output() approveEvent: EventEmitter<void> = new EventEmitter();
+  @Output() denyEvent: EventEmitter<void> = new EventEmitter();
 
   constructor() {}
 

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.html
@@ -48,7 +48,10 @@
             ></dp-current-result-city-staff>
             <ng-container [ngSwitch]="petition?.status">
               <ng-container class="flex" *ngSwitchCase="'NEW'">
-                <dp-new-box (aproveEvent)="aproveDialog()"></dp-new-box>
+                <dp-new-box
+                  (aproveEvent)="approveDialog()"
+                  (denyEvent)="denyAlert()"
+                ></dp-new-box>
               </ng-container>
               <ng-container class="flex" *ngSwitchCase="'QUALIFIED'">
                 <dp-cualified-box

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.component.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.component.ts
@@ -8,10 +8,12 @@ import {
   PetitionStatus,
 } from 'src/app/core/api/API';
 import { GetPetitionService } from 'src/app/logic/petition/get-petition.service';
+import { DialogResultComponent } from 'src/app/shared/dialog-result/dialog-result.component';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 import { AlertWithdrawlPetitionComponent } from '../view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component';
 import { ConfirmWithdrawlPetitionComponent } from '../view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component';
 import { ApproveDialogComponent } from './approve-dialog/approve-dialog.component';
+import { DenyAlertComponent } from './deny-alert/deny-alert.component';
 
 @Component({
   selector: 'dp-view-petition-city-staff',
@@ -62,13 +64,34 @@ export class ViewPetitionCityStaffComponent implements OnInit {
       : undefined;
   }
 
-  aproveDialog(): void {
+  approveDialog(): void {
     const dialogRef = this._dialog.open(ApproveDialogComponent, {
       width: '690px',
     });
 
     dialogRef.afterClosed().subscribe((result) => {
       console.log('The dialog was closed ' + result);
+    });
+  }
+
+  denyAlert() {
+    const dialogRef = this._dialog.open(DenyAlertComponent, {
+      width: '480px',
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this._dialog.open(DialogResultComponent, {
+          width: '520px',
+          data: {
+            title: 'Petition Denied!',
+            message: '',
+            success: true,
+          },
+        });
+      } else {
+        this._dialog.closeAll();
+      }
     });
   }
 }

--- a/src/app/features/view-petition-city-staff/view-petition-city-staff.module.ts
+++ b/src/app/features/view-petition-city-staff/view-petition-city-staff.module.ts
@@ -12,6 +12,8 @@ import { GetPetitionService } from 'src/app/logic/petition/get-petition.service'
 import { NewBoxModule } from './new-box/new-box.module';
 import { CualifiedBoxModule } from './cualified-box/cualified-box.module';
 import { ApproveDialogModule } from './approve-dialog/approve-dialog.module';
+import { DenyAlertModule } from './deny-alert/deny-alert.module';
+import { DialogResultModule } from 'src/app/shared/dialog-result/dialog-result.module';
 
 @NgModule({
   declarations: [ViewPetitionCityStaffComponent],
@@ -27,6 +29,8 @@ import { ApproveDialogModule } from './approve-dialog/approve-dialog.module';
     NewBoxModule,
     CualifiedBoxModule,
     ApproveDialogModule,
+    DenyAlertModule,
+    DialogResultModule,
   ],
   providers: [GetPetitionService],
 })


### PR DESCRIPTION
Problem: Add UI support to reject a petition(City Staff)
Description: Provide interface support for the denial process of a petition by a city staff user.
Solution:
Create the deny-alert component
Alert launched when trying to deny a request, warns the user of the action he is trying to perform

Add the interface elements to deny a request

Add the call to the function "deny petition"