### PR TITLE
DP-182 Add ui support to petition certification packet

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -166,6 +166,13 @@ const routes: Routes = [
           ).then((m) => m.ViewPetitionCityStaffModule),
       },
       {
+        path: 'home/:id/signatures',
+        loadChildren: () =>
+          import('./features/view-signatures/view-signatures.module').then(
+            (m) => m.ViewSignaturesModule
+          ),
+      },
+      {
         path: 'admin',
         loadChildren: () =>
           import('./city-staff/admin/admin.module').then((m) => m.AdminModule),

--- a/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.component.html
+++ b/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.component.html
@@ -1,0 +1,6 @@
+<div [class]="currentStyle" *ngIf="!show">
+  <p class="text-sm leading-[18px]">{{ message }}</p>
+  <button class="h-4 w-4" mat-icon-button (click)="show = !show">
+    <mat-icon class="h-4 w-4" [svgIcon]="'custom_icons:close'"></mat-icon>
+  </button>
+</div>

--- a/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.component.spec.ts
+++ b/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewSignaturesAlertComponent } from './view-signatures-alert.component';
+
+describe('ViewSignaturesAlertComponent', () => {
+  let component: ViewSignaturesAlertComponent;
+  let fixture: ComponentFixture<ViewSignaturesAlertComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewSignaturesAlertComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ViewSignaturesAlertComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.component.ts
+++ b/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.component.ts
@@ -1,0 +1,67 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
+
+@Component({
+  selector: 'dp-view-signatures-alert',
+  templateUrl: './view-signatures-alert.component.html',
+})
+export class ViewSignaturesAlertComponent implements OnInit, OnChanges {
+  @Input() type!: 'alert' | 'success' | 'error';
+  @Input() message!: string;
+  @Input() show: boolean = false;
+
+  protected currentStyle = '';
+  protected alertStyle =
+    'flex flex-row w-full justify-between py-[27px] px-6 bg-[#FFEF98] rounded-lg';
+  protected successStyle =
+    'flex flex-row md:max-w-[500px] w-full justify-between py-[27px] px-6 bg-[#E6FFE2] rounded-lg';
+  protected errorStyle =
+    'flex flex-row md:max-w-[500px] w-full justify-between py-[27px] px-6 bg-red-500 rounded-lg';
+
+  constructor() {
+    switch (this.type) {
+      case 'alert':
+        this.currentStyle = this.alertStyle;
+        break;
+      case 'success':
+        this.currentStyle = this.successStyle;
+        break;
+      case 'error':
+        this.currentStyle = this.errorStyle;
+    }
+  }
+  ngOnChanges(changes: SimpleChanges): void {
+    switch (this.type) {
+      case 'alert':
+        this.currentStyle = this.alertStyle;
+        break;
+      case 'success':
+        this.currentStyle = this.successStyle;
+        break;
+      case 'error':
+        this.currentStyle = this.errorStyle;
+    }
+  }
+
+  ngOnInit(): void {
+    switch (this.type) {
+      case 'alert':
+        this.currentStyle = this.alertStyle;
+        break;
+      case 'success':
+        this.currentStyle = this.successStyle;
+        break;
+      case 'error':
+        this.currentStyle = this.errorStyle;
+    }
+  }
+
+  onCancelClick() {
+    this.show = false;
+  }
+}

--- a/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.module.ts
+++ b/src/app/features/view-signatures/view-signatures-alert/view-signatures-alert.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ViewSignaturesAlertComponent } from './view-signatures-alert.component';
+import { MatIconModule } from '@angular/material/icon';
+
+@NgModule({
+  declarations: [ViewSignaturesAlertComponent],
+  imports: [CommonModule, MatIconModule],
+  exports: [ViewSignaturesAlertComponent],
+})
+export class ViewSignaturesAlertModule {}

--- a/src/app/features/view-signatures/view-signatures-routing.module.ts
+++ b/src/app/features/view-signatures/view-signatures-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ViewSignaturesComponent } from './view-signatures.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ViewSignaturesComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ViewSignaturesRoutingModule {}

--- a/src/app/features/view-signatures/view-signatures.component.html
+++ b/src/app/features/view-signatures/view-signatures.component.html
@@ -1,0 +1,51 @@
+<div class="flex flex-col w-full gap-6">
+  <dp-view-signatures-alert
+    class="flex w-full justify-center"
+    [type]="'success'"
+    [message]="'1 Signature Successfully Denied!'"
+  ></dp-view-signatures-alert>
+  <div class="flex flex-col w-full gap-[43px]">
+    <dp-return-link
+      [route]="'/city-staff/home'"
+      [text]="'Back to Petition List'"
+    ></dp-return-link>
+    <h3 class="font-bold leading-7">Petition Title</h3>
+  </div>
+  <div class="flex flex-row justify-end">
+    <dp-basic-filter
+      class="w-full md:max-w-[250px] md:min-w-[150px]"
+      [filterName]="'Filter by Status'"
+      [elements]="filterByStatus"
+      [disabled]="disabledFilter"
+      [mode]="'Select'"
+      (event)="filterStatus($event)"
+    ></dp-basic-filter>
+  </div>
+
+  <div class="flex flex-row justify-between">
+    <div
+      class="flex border border-[#D7D7D7] rounded-lg bg-[#FFFFFF] px-2 justify-center items-center"
+    >
+      <mat-checkbox color="primary"
+        ><p class="text-xs font-bold">Showing 100</p></mat-checkbox
+      >
+    </div>
+    <div class="flex flex-row gap-[10px] max-w-[439px] w-full">
+      <dp-basic-search-engine
+        (event)="search($event)"
+        [disabled]="disabledFilter"
+        class="w-full min-w-[100px]"
+      ></dp-basic-search-engine>
+      <dp-basic-filter
+        class="w-full md:max-w-[125px] md:min-w-[100px]"
+        [filterName]="'Sort by'"
+        [elements]="sortBy"
+        [disabled]="disabledFilter"
+        [mode]="'Select'"
+        (event)="sort($event)"
+      ></dp-basic-filter>
+    </div>
+  </div>
+
+  <dp-view-signatures-table></dp-view-signatures-table>
+</div>

--- a/src/app/features/view-signatures/view-signatures.component.html
+++ b/src/app/features/view-signatures/view-signatures.component.html
@@ -46,6 +46,4 @@
       ></dp-basic-filter>
     </div>
   </div>
-
-  <dp-view-signatures-table></dp-view-signatures-table>
 </div>

--- a/src/app/features/view-signatures/view-signatures.component.spec.ts
+++ b/src/app/features/view-signatures/view-signatures.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewSignaturesComponent } from './view-signatures.component';
+
+describe('ViewSignaturesComponent', () => {
+  let component: ViewSignaturesComponent;
+  let fixture: ComponentFixture<ViewSignaturesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewSignaturesComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ViewSignaturesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/view-signatures/view-signatures.component.ts
+++ b/src/app/features/view-signatures/view-signatures.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { FilterData } from 'src/app/shared/models/exports';
+
+@Component({
+  selector: 'dp-view-signatures',
+  templateUrl: './view-signatures.component.html',
+})
+export class ViewSignaturesComponent implements OnInit {
+  protected disabledFilter: boolean = false;
+  private currentFilter: FilterData[] = [
+    {
+      property: 'Status',
+      value: 'All',
+      page: 0,
+    },
+    {
+      property: 'Search',
+      value: '',
+      page: 0,
+    },
+  ];
+  protected sortBy: {
+    name: string;
+    value: string;
+    active: boolean;
+  }[] = [
+    { name: 'All types', value: 'all', active: true },
+    { name: 'Signer Name', value: 'Signer Name', active: false },
+    { name: 'Signer Date', value: 'Signer Date', active: false },
+    { name: 'Address', value: 'Address', active: false },
+    { name: 'Email', value: 'Email', active: false },
+    { name: 'Status', value: 'Status', active: false },
+  ];
+  protected filterByStatus: {
+    name: string;
+    value: string;
+    active: boolean;
+  }[] = [
+    { name: 'All types', value: 'all', active: true },
+    { name: 'Registered', value: 'registered', active: false },
+    { name: 'Approved', value: 'approved', active: false },
+    { name: 'Denied', value: 'denied', active: false },
+  ];
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  search(value: string) {}
+  sort(value: string) {}
+  filterStatus(value: string) {}
+}

--- a/src/app/features/view-signatures/view-signatures.module.ts
+++ b/src/app/features/view-signatures/view-signatures.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ViewSignaturesComponent } from './view-signatures.component';
-import { ViewSignaturesTableModule } from './view-signatures-table/view-signatures-table.module';
 import { ViewSignaturesRoutingModule } from './view-signatures-routing.module';
 import { ViewSignaturesAlertModule } from './view-signatures-alert/view-signatures-alert.module';
 import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
@@ -13,7 +12,6 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
   declarations: [ViewSignaturesComponent],
   imports: [
     CommonModule,
-    ViewSignaturesTableModule,
     ViewSignaturesAlertModule,
     ViewSignaturesRoutingModule,
     ReturnLinkModule,

--- a/src/app/features/view-signatures/view-signatures.module.ts
+++ b/src/app/features/view-signatures/view-signatures.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ViewSignaturesComponent } from './view-signatures.component';
+import { ViewSignaturesTableModule } from './view-signatures-table/view-signatures-table.module';
+import { ViewSignaturesRoutingModule } from './view-signatures-routing.module';
+import { ViewSignaturesAlertModule } from './view-signatures-alert/view-signatures-alert.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { BasicSearchEngineModule } from 'src/app/shared/basic-search-engine/basic-search-engine.module';
+import { BasicFilterModule } from 'src/app/shared/basic-filter/basic-filter.module';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+
+@NgModule({
+  declarations: [ViewSignaturesComponent],
+  imports: [
+    CommonModule,
+    ViewSignaturesTableModule,
+    ViewSignaturesAlertModule,
+    ViewSignaturesRoutingModule,
+    ReturnLinkModule,
+    BasicSearchEngineModule,
+    BasicFilterModule,
+    MatCheckboxModule,
+  ],
+})
+export class ViewSignaturesModule {}


### PR DESCRIPTION
Problem: Add UI support to Petition Certification packet.
Description: An interface is required to support the flow of approval or denial of signatures in a petition.
Solution:
Create the alert element of the view-signatures component
The informative component is created to display notifications to the user regarding the actions performed on the interface.
Create the view-signatures component
The component that allows to list the signatures of a petition is created. The component displays an alert, a filter, a search engine, and a sorter.
Add a route to see the signatures of a petition