### PR TITLE
DP265 - fix invited admin users can't sign in

### DIFF
--- a/src/app/auth/sign-in/components/change-password/change-password.component.html
+++ b/src/app/auth/sign-in/components/change-password/change-password.component.html
@@ -1,0 +1,44 @@
+<form
+  class="grid grid-cols-1 gap-[16px]"
+  [formGroup]="formGroup"
+  (ngSubmit)="submit()"
+>
+  <div class="w-full flex flex-col justify-end">
+    <mat-form-field>
+      <mat-label>New password</mat-label>
+      <input
+        matInput
+        [type]="hidePassword ? 'password' : 'text'"
+        formControlName="password"
+      />
+      <!-- *ngIf="formGroup.get('password')!.getError('required')" -->
+      <mat-error>
+        <div class="flex flex-row items-center">
+          <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
+          <span class="ml-[9px]">Password is required</span>
+        </div>
+      </mat-error>
+      <button
+        type="button"
+        matSuffix
+        mat-icon-button
+        (click)="hidePassword = !hidePassword"
+      >
+        <mat-icon
+          [svgIcon]="
+            hidePassword ? 'custom_icons:edge' : 'custom_icons:no-edge'
+          "
+        ></mat-icon>
+      </button>
+    </mat-form-field>
+  </div>
+  <button
+    mat-flat-button
+    type="submit"
+    class="h-10 w-full mt-2"
+    color="primary"
+    [disabled]="loading"
+  >
+    Change
+  </button>
+</form>

--- a/src/app/auth/sign-in/components/change-password/change-password.component.spec.ts
+++ b/src/app/auth/sign-in/components/change-password/change-password.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangePasswordComponent } from './change-password.component';
+
+describe('ChangePasswordComponent', () => {
+  let component: ChangePasswordComponent;
+  let fixture: ComponentFixture<ChangePasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ChangePasswordComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ChangePasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/auth/sign-in/components/change-password/change-password.component.spec.ts
+++ b/src/app/auth/sign-in/components/change-password/change-password.component.spec.ts
@@ -8,9 +8,8 @@ describe('ChangePasswordComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ChangePasswordComponent ]
-    })
-    .compileComponents();
+      declarations: [ChangePasswordComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ChangePasswordComponent);
     component = fixture.componentInstance;

--- a/src/app/auth/sign-in/components/change-password/change-password.component.ts
+++ b/src/app/auth/sign-in/components/change-password/change-password.component.ts
@@ -1,0 +1,32 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+
+@Component({
+  selector: 'dp-change-password',
+  templateUrl: './change-password.component.html',
+})
+export class ChangePasswordComponent implements OnInit {
+  @Input() loading: boolean | null = false;
+  @Output() changePassword = new EventEmitter<{ password: string | null }>();
+
+  protected hidePassword = true;
+
+  protected formGroup!: FormGroup<{ password: FormControl<string | null> }>;
+
+  constructor(private _fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.formGroup = this._fb.group({ password: ['', [Validators.required]] });
+  }
+
+  submit() {
+    if (this.formGroup.invalid) return;
+
+    this.changePassword.emit(this.formGroup.getRawValue());
+  }
+}

--- a/src/app/auth/sign-in/sign-in.component.html
+++ b/src/app/auth/sign-in/sign-in.component.html
@@ -1,91 +1,113 @@
-<div class="w-full flex justify-center">
+<div class="w-full flex justify-center" *ngIf="viewState$ | async as viewState">
   <div class="flex flex-col max-w-[432px] w-full">
     <h1 class="p-6 font-extrabold">Petition Creators</h1>
-    <form [formGroup]="formGroup" (ngSubmit)="submit()">
-      <dp-basic-card class="w-full">
-        <div class="w-full flex justify-start">
-          <h4 class="font-bold text-lg">Create an account</h4>
-        </div>
-        <dp-error-msg
-          *ngIf="!(loading$ | async) && (error$ | async) as error"
-          [error]="error"
-        >
-        </dp-error-msg>
-        <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
-        <div class="grid grid-cols-1 gap-[16px]">
+    <dp-basic-card class="w-full">
+      <div class="w-full flex justify-start">
+        <h4 class="font-bold text-lg">
+          {{ viewState === "LOGIN" ? "Create an account" : "Change password" }}
+        </h4>
+      </div>
+      <dp-error-msg
+        *ngIf="
+          !(loading$ | async) &&
+          viewState == 'LOGIN' &&
+          (_signInLogic.error$ | async) as error
+        "
+        [error]="error"
+      >
+      </dp-error-msg>
+      <dp-error-msg
+        *ngIf="
+          !(loading$ | async) &&
+          viewState != 'LOGIN' &&
+          (_completeNewPasswordLogic.error$ | async) as error
+        "
+        [error]="error"
+      >
+      </dp-error-msg>
+      <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
+      <form
+        class="grid grid-cols-1 gap-[16px]"
+        [formGroup]="formGroup"
+        (ngSubmit)="submit()"
+        *ngIf="viewState === 'LOGIN'; else changePassword"
+      >
+        <mat-form-field>
+          <mat-label>Email</mat-label>
+          <input type="text" matInput formControlName="email" />
+          <mat-error *ngIf="formGroup.get('email')!.getError('required')">
+            <div class="flex flex-row items-center">
+              <mat-icon
+                class="w-[14px] h-[14px]"
+                [svgIcon]="'custom_icons:c_close'"
+              ></mat-icon>
+              <span class="ml-[9px]">Email is required</span>
+            </div>
+          </mat-error>
+          <mat-error *ngIf="formGroup.get('email')!.getError('email')">
+            <div class="flex flex-row items-center">
+              <mat-icon
+                class="w-[14px] h-[14px]"
+                [svgIcon]="'custom_icons:c_close'"
+              ></mat-icon>
+              <span class="ml-[9px]">Email is incorrect</span>
+            </div>
+          </mat-error>
+        </mat-form-field>
+        <span class="w-full flex flex-col justify-end">
           <mat-form-field>
-            <mat-label>Email</mat-label>
-            <input type="text" matInput formControlName="email" />
-            <mat-error *ngIf="formGroup.get('email')!.getError('required')">
+            <mat-label>Password</mat-label>
+            <input
+              matInput
+              [type]="hidePassword ? 'password' : 'text'"
+              formControlName="password"
+            />
+            <mat-error *ngIf="formGroup.get('password')!.getError('required')">
               <div class="flex flex-row items-center">
-                <mat-icon
-                  class="w-[14px] h-[14px]"
-                  [svgIcon]="'custom_icons:c_close'"
-                ></mat-icon>
-                <span class="ml-[9px]">Email is required</span>
+                <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
+                <span class="ml-[9px]">Password is required</span>
               </div>
             </mat-error>
-            <mat-error *ngIf="formGroup.get('email')!.getError('email')">
-              <div class="flex flex-row items-center">
-                <mat-icon
-                  class="w-[14px] h-[14px]"
-                  [svgIcon]="'custom_icons:c_close'"
-                ></mat-icon>
-                <span class="ml-[9px]">Email is incorrect</span>
-              </div>
-            </mat-error>
+            <button
+              type="button"
+              matSuffix
+              mat-icon-button
+              (click)="hidePassword = !hidePassword"
+            >
+              <mat-icon
+                [svgIcon]="
+                  hidePassword ? 'custom_icons:edge' : 'custom_icons:no-edge'
+                "
+              ></mat-icon>
+            </button>
           </mat-form-field>
-          <span class="w-full flex flex-col justify-end">
-            <mat-form-field>
-              <mat-label>Password</mat-label>
-              <input
-                matInput
-                [type]="hidePassword ? 'password' : 'text'"
-                formControlName="password"
-              />
-              <mat-error
-                *ngIf="formGroup.get('password')!.getError('required')"
+          <span class="w-full flex justify-end">
+            <a [routerLink]="'/auth/forgot-password'"
+              ><h4
+                class="font-extrabold text-base tracking-wide text-primary-500"
               >
-                <div class="flex flex-row items-center">
-                  <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
-                  <span class="ml-[9px]">Password is required</span>
-                </div>
-              </mat-error>
-              <button
-                type="button"
-                matSuffix
-                mat-icon-button
-                (click)="hidePassword = !hidePassword"
-              >
-                <mat-icon
-                  [svgIcon]="
-                    hidePassword ? 'custom_icons:edge' : 'custom_icons:no-edge'
-                  "
-                ></mat-icon>
-              </button>
-            </mat-form-field>
-            <span class="w-full flex justify-end">
-              <a [routerLink]="'/auth/forgot-password'"
-                ><h4
-                  class="font-extrabold text-base tracking-wide text-primary-500"
-                >
-                  Forgot Password?
-                </h4></a
-              >
-            </span>
+                Forgot Password?
+              </h4></a
+            >
           </span>
-          <button
-            mat-flat-button
-            type="submit"
-            class="h-10 w-full mt-2"
-            color="primary"
-            [disabled]="loading$ | async"
-          >
-            Log In
-          </button>
-        </div>
-      </dp-basic-card>
-    </form>
+        </span>
+        <button
+          mat-flat-button
+          type="submit"
+          class="h-10 w-full mt-2"
+          color="primary"
+          [disabled]="loading$ | async"
+        >
+          Log In
+        </button>
+      </form>
+      <ng-template #changePassword>
+        <dp-change-password
+          [loading]="loading$ | async"
+          (changePassword)="onChangePassword($event)"
+        ></dp-change-password>
+      </ng-template>
+    </dp-basic-card>
     <div class="my-6 w-full flex flex-row justify-center">
       <h4 class="font-extrabold text-base tracking-wide">
         Don't have an account?

--- a/src/app/auth/sign-in/sign-in.module.ts
+++ b/src/app/auth/sign-in/sign-in.module.ts
@@ -12,9 +12,10 @@ import { SingInRoutingModule } from './sign-in-routing.module';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
 import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
+import { ChangePasswordComponent } from './components/change-password/change-password.component';
 
 @NgModule({
-  declarations: [SignInComponent],
+  declarations: [SignInComponent, ChangePasswordComponent],
   imports: [
     CommonModule,
     SingInRoutingModule,

--- a/src/app/core/layout/user-menu/user-menu.component.ts
+++ b/src/app/core/layout/user-menu/user-menu.component.ts
@@ -27,7 +27,7 @@ export class UserMenuComponent implements OnInit, OnDestroy {
         tap((result) => {
           if (!!result.result) {
             this._router.navigate(['/auth/login']);
-            this._accountLogic.isLoged();
+            this._accountLogic.getCurrentUser();
           } else {
             //I'm not sure this is the best way to handle errors here
             this.openDialog(
@@ -41,7 +41,7 @@ export class UserMenuComponent implements OnInit, OnDestroy {
       )
       .subscribe();
     this.currentUser$ = this._accountLogic.currentUser$;
-    this.isLoged$ = this._accountLogic.isLoged$;
+    this.isLoged$ = this._accountLogic.isAuthenticated$;
   }
 
   ngOnInit(): void {}

--- a/src/app/guards/account-setting.guard.ts
+++ b/src/app/guards/account-setting.guard.ts
@@ -22,7 +22,7 @@ export class AccountSettingGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._auth.isLoged().pipe(
+    return this._auth.getCurrentUser().pipe(
       map((data) => {
         if (data) {
           return true;

--- a/src/app/guards/anonimous.guard.ts
+++ b/src/app/guards/anonimous.guard.ts
@@ -22,7 +22,7 @@ export class AnonimousGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._auth.isLoged().pipe(
+    return this._auth.getCurrentUser().pipe(
       map((data) => {
         if (data) {
           return this._router.parseUrl('/auth/login');

--- a/src/app/guards/city-staff.guard.ts
+++ b/src/app/guards/city-staff.guard.ts
@@ -22,7 +22,7 @@ export class CityStaffGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._auth.isLoged().pipe(
+    return this._auth.getCurrentUser().pipe(
       map((data) => {
         if (data?.attributes['custom:access_group'] === 'admin') {
           return true;

--- a/src/app/guards/committee.guard.ts
+++ b/src/app/guards/committee.guard.ts
@@ -20,7 +20,7 @@ export class CommitteeGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._auth.isLoged().pipe(
+    return this._auth.getCurrentUser().pipe(
       map((data) => {
         if (data?.attributes['custom:access_group'] === 'petitioner') {
           return true;

--- a/src/app/guards/noAuth.guard.ts
+++ b/src/app/guards/noAuth.guard.ts
@@ -22,7 +22,7 @@ export class NoAuthGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._auth.isLoged().pipe(
+    return this._auth.getCurrentUser().pipe(
       map((data) => {
         if (data?.attributes['custom:access_group'] === 'petitioner') {
           return this._router.parseUrl('/committee/home');

--- a/src/app/logic/auth/complete-new-password.service.spec.ts
+++ b/src/app/logic/auth/complete-new-password.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CompleteNewPasswordService } from './complete-new-password.service';
+
+describe('CompleteNewPasswordService', () => {
+  let service: CompleteNewPasswordService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CompleteNewPasswordService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/logic/auth/exports.ts
+++ b/src/app/logic/auth/exports.ts
@@ -3,6 +3,7 @@ export * from './change-password.service';
 export * from './change-personal-details.service';
 export * from './check-token-fp.service';
 export * from './confirm-change-email.service';
+export * from './complete-new-password.service';
 export * from './forgot-password.service';
 export * from './set-new-password.service';
 export * from './sign-in.service';

--- a/src/app/shared/models/auth/user.ts
+++ b/src/app/shared/models/auth/user.ts
@@ -15,6 +15,7 @@ export interface User {
 }
 
 export interface CognitoUserFacade {
-  username: string;
   attributes: Attributes;
+  challengeName: 'NEW_PASSWORD_REQUIRED';
+  username: string;
 }


### PR DESCRIPTION
**Problem:**
Invited admin users can't sign in.

**Description:**
The invited users need to change the password the first time they sign in otherwise Cognito will not let the user sign in.

**Solution:**
Check if the sign in method returns a NEW_PASSWORD_REQUIRED challenge, if true then change the sign in UI for a new one that allows the user to enter a new password. Behind the scenes, when the user enters the new password a new method of Cognito is called using the previous sign in attempt result and this time will sign in the user in the app. Some extra job was done to redirect the user to the home page after the password was changed.

**Further work:**
In order to change the password some data is needed like the user's Given Name or Family Name. Right now this is hardcoded to a placeholder which makes the UI to show dummy data. The proposed approach to solve this is to include more form fields in the change password form.