### PR TITLE
DP-254 Design and implement the unit tests of the function view details a petition home

### DIFF
--- a/src/app/features/account-settings/account-settings.component.html
+++ b/src/app/features/account-settings/account-settings.component.html
@@ -40,7 +40,10 @@
           <p class="font-bold leading-5 md:min-w-[150px]">
             Contact information
           </p>
-          <p class="max-w-full">
+          <p
+            class="max-w-full"
+            *ngIf="user.attributes.given_name || user.attributes.family_name"
+          >
             {{ user.attributes.given_name + " " + user.attributes.family_name }}
           </p>
           <button

--- a/src/app/features/edit-petition/confirm-edit-petition/confirm-edit-petition.component.ts
+++ b/src/app/features/edit-petition/confirm-edit-petition/confirm-edit-petition.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'dp-confirm-edit-petition',

--- a/src/app/features/edit-petition/edit-petition-issue/edit-petition-issue.component.ts
+++ b/src/app/features/edit-petition/edit-petition-issue/edit-petition-issue.component.ts
@@ -9,10 +9,9 @@ import {
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { Observable, shareReplay, tap } from 'rxjs';
-import { IssuePetition, Petition } from 'src/app/core/api/API';
+import { Observable, tap } from 'rxjs';
+import { IssuePetition } from 'src/app/core/api/API';
 import { EditPetitionIssueService } from 'src/app/logic/petition/edit-petition-issue.service';
-import { IssuePetitionData, Result } from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 import { ConfirmEditPetitionComponent } from '../confirm-edit-petition/confirm-edit-petition.component';
 
@@ -75,6 +74,7 @@ export class EditPetitionIssueComponent implements OnInit, OnChanges {
         .subscribe();
     }
   }
+
   cancel() {
     this._cancelEvent.emit();
   }

--- a/src/app/features/edit-petition/edit-petition.component.html
+++ b/src/app/features/edit-petition/edit-petition.component.html
@@ -9,7 +9,7 @@
       <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
       <ng-container *ngIf="(success$ | async) && !result">
         <dp-return-link
-          [route]="'/committee/home/' + _activatedRoute.snapshot.params['id']"
+          [route]="'/committee/home/' + id"
           [text]="'Back to Petition'"
         ></dp-return-link>
         <h2 class="mt-[18px] leading-[30px] font-extrabold">Edit Petition</h2>

--- a/src/app/features/edit-petition/edit-petition.component.html
+++ b/src/app/features/edit-petition/edit-petition.component.html
@@ -1,96 +1,65 @@
 <div class="flex w-full justify-center">
   <div class="flex flex-col max-w-[550px] w-full">
     <div class="w-full flex flex-col py-12 gap-6">
-      <ng-container [ngSwitch]="currentStep$ | async">
-        <ng-container *ngSwitchCase="'loading'">
-          <div class="flex justify-center w-full">
-            <h3 class="leading-7 font-extrabold">Loading</h3>
-          </div>
+      <dp-error-msg
+        *ngIf="!(loading$ | async) && (error$ | async) as error"
+        [error]="error"
+      >
+      </dp-error-msg>
+      <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
+      <ng-container *ngIf="(success$ | async) && !result">
+        <dp-return-link
+          [route]="'/committee/home/' + _activatedRoute.snapshot.params['id']"
+          [text]="'Back to Petition'"
+        ></dp-return-link>
+        <h2 class="mt-[18px] leading-[30px] font-extrabold">Edit Petition</h2>
+      </ng-container>
 
-          <mat-progress-bar
-            mode="indeterminate"
-            color="primary"
-          ></mat-progress-bar>
-        </ng-container>
-        <ng-container class="flex" *ngSwitchCase="'error'">
+      <ng-container *ngIf="result">
+        <div class="w-full flex flex-col">
           <div class="flex justify-center w-full">
-            <h3 class="leading-7 font-extrabold">An error has occurred</h3>
+            <h3 class="leading-7 font-extrabold">
+              Your petition has been successfully resubmitted!
+            </h3>
           </div>
-
-          <div class="flex flex-row items-center justify-center">
+          <div class="flex justify-center w-full">
             <mat-icon
-              class="w-[14px] h-[14px]"
-              [svgIcon]="'custom_icons:c_close'"
+              class="text-green-500 w-[26.67px] h-[26.67px]"
+              [svgIcon]="'custom_icons:like'"
             ></mat-icon>
-            <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
           </div>
-          <div class="flex flex-row items-center justify-center">
-            <dp-return-link
-              [route]="'/example'"
-              [text]="'Back to Petition'"
-            ></dp-return-link>
-          </div>
-        </ng-container>
-        <ng-container *ngSwitchCase="'candidate'">
-          <dp-return-link
-            [route]="'/committee/home/' + _activatedRoute.snapshot.params['id']"
-            [text]="'Back to Petition'"
-          ></dp-return-link>
-          <h2 class="mt-[18px] leading-[30px] font-extrabold">Edit Petition</h2>
-        </ng-container>
-        <ng-container *ngSwitchCase="'issue'">
-          <dp-return-link
-            [route]="'/committee/home/' + _activatedRoute.snapshot.params['id']"
-            [text]="'Back to Petition'"
-          ></dp-return-link>
-          <h2 class="mt-[18px] leading-[30px] font-extrabold">Edit Petition</h2>
-        </ng-container>
-        <ng-container *ngSwitchCase="'result'">
-          <div class="w-full flex flex-col">
-            <div class="flex justify-center w-full">
-              <h3 class="leading-7 font-extrabold">
-                Your petition has been successfully resubmitted!
-              </h3>
-            </div>
-            <div class="flex justify-center w-full">
-              <mat-icon
-                class="text-green-500 w-[26.67px] h-[26.67px]"
-                [svgIcon]="'custom_icons:like'"
-              ></mat-icon>
-            </div>
-          </div>
-        </ng-container>
+        </div>
       </ng-container>
 
       <div class="flex justify-center w-full"></div>
 
-      <div class="flex justify-center w-full">
-        <ng-container [ngSwitch]="currentStep$ | async">
-          <dp-edit-petition-candidate
-            class="w-full"
-            [formData]="resultData"
-            (_cancelEvent)="cancel()"
-            (_submitEvent)="submitCandidate($event)"
-            *ngSwitchCase="'candidate'"
-          >
-          </dp-edit-petition-candidate>
-          <dp-edit-petition-issue
-            class="w-full"
-            [formData]="resultData"
-            (_cancelEvent)="cancel()"
-            (_submitEvent)="submitIssue($event)"
-            *ngSwitchCase="'issue'"
-          >
-          </dp-edit-petition-issue>
-        </ng-container>
-        <ng-container [ngSwitch]="currentStep$ | async">
-          <dp-edit-result-petition
-            class="w-full"
-            [data]="resultData"
-            *ngSwitchCase="'result'"
-          >
-          </dp-edit-result-petition>
-        </ng-container>
+      <div
+        class="flex justify-center w-full"
+        *ngIf="success$ | async as resultData"
+      >
+        <dp-edit-petition-candidate
+          class="w-full"
+          [formData]="resultData"
+          (_cancelEvent)="cancel()"
+          (_submitEvent)="submitCandidate($event)"
+          *ngIf="resultData.dataCandidate && !result"
+        >
+        </dp-edit-petition-candidate>
+        <dp-edit-petition-issue
+          class="w-full"
+          [formData]="resultData"
+          (_cancelEvent)="cancel()"
+          (_submitEvent)="submitIssue($event)"
+          *ngIf="resultData.dataIssue && !result"
+        >
+        </dp-edit-petition-issue>
+
+        <dp-edit-result-petition
+          class="w-full"
+          [data]="dataResponse"
+          *ngIf="result"
+        >
+        </dp-edit-result-petition>
       </div>
     </div>
   </div>

--- a/src/app/features/edit-petition/edit-petition.component.spec.ts
+++ b/src/app/features/edit-petition/edit-petition.component.spec.ts
@@ -1,23 +1,171 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BasicModalModule } from 'src/app/shared/basic-modal/basic-modal.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { EditPetitionCandidateModule } from './edit-petition-candidate/edit-petition-candidate.module';
+import { EditPetitionIssueModule } from './edit-petition-issue/edit-petition-issue.module';
+import { EditPetitionRoutingModule } from './edit-petition-routing.module';
+import {
+  exhaustMap,
+  map,
+  merge,
+  Observable,
+  of,
+  partition,
+  ReplaySubject,
+  shareReplay,
+  Subject,
+  tap,
+} from 'rxjs';
 import { EditPetitionComponent } from './edit-petition.component';
+import { EditResultPetitionModule } from './edit-result-petition/edit-result-petition.module';
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+import { Result } from 'src/app/shared/models/exports';
+import { PetitionService } from 'src/app/logic/petition/petition.service';
+import { LoggingService } from 'src/app/core/logging/loggin.service';
+import { GetCommitteePetitionService } from 'src/app/logic/petition/get-committee-petition.service';
+import {
+  IssuePetition,
+  PetitionStatus,
+  PetitionType,
+} from 'src/app/core/api/API';
 
 describe('EditPetitionComponent', () => {
   let component: EditPetitionComponent;
   let fixture: ComponentFixture<EditPetitionComponent>;
+  let _getCommitteePetitionService: GetCommitteePetitionService;
+
+  const mockedIssue: IssuePetition = {
+    __typename: 'IssuePetition',
+    PK: '',
+    createdAt: '',
+    detail: 'Text',
+    owner: '',
+    signatures: {
+      __typename: 'SignatureConnection',
+      items: [],
+      token: undefined,
+    },
+    status: PetitionStatus.NEW,
+    title: 'Title',
+    type: PetitionType.ISSUE,
+    updatedAt: '',
+    version: 0,
+  };
+
+  class MockedGetCommitteePetitionService {
+    public error$: Observable<string | undefined>;
+    public success$: Observable<ResponsePetition | undefined>;
+    public loading$: Observable<boolean>;
+    public result$: Observable<Result<ResponsePetition>>;
+    private submit$: ReplaySubject<string> = new ReplaySubject();
+
+    constructor() {
+      this.result$ = this.submit$.pipe(
+        exhaustMap((_) =>
+          of({
+            result: { dataIssue: mockedIssue },
+          })
+        ),
+        shareReplay(1)
+      );
+      const [success$, error$] = partition(this.result$, (value) =>
+        value.result ? true : false
+      );
+
+      this.success$ = success$.pipe(
+        map((value) => value.result),
+
+        shareReplay(1)
+      );
+
+      this.error$ = error$.pipe(
+        map((value) => value.error),
+
+        shareReplay(1)
+      );
+
+      const end$ = merge(this.success$, this.error$);
+
+      this.loading$ = merge(
+        this.submit$.pipe(
+          map((v) => true),
+          tap(() => console.log('start'))
+        ),
+        end$.pipe(
+          map((v) => false),
+          tap(() => console.log('end'))
+        )
+      ).pipe(shareReplay(1));
+    }
+    ngOnDestroy(): void {
+      this.submit$.complete();
+    }
+
+    getPetition(id: string) {
+      this.submit$.next(id);
+    }
+  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ EditPetitionComponent ]
-    })
-    .compileComponents();
+      declarations: [EditPetitionComponent],
+      imports: [
+        CommonModule,
+        RouterModule,
+        EditPetitionCandidateModule,
+        EditPetitionIssueModule,
+        EditPetitionRoutingModule,
+        ReturnLinkModule,
+        MatDialogModule,
+        BasicModalModule,
+        EditResultPetitionModule,
+        MatIconModule,
+        MatProgressBarModule,
+        MatButtonModule,
+        LoadingBarModule,
+        ErrorMsgModule,
+        RouterTestingModule,
+        BrowserAnimationsModule,
+      ],
+      providers: [
+        EditPetitionComponent,
+        {
+          provide: GetCommitteePetitionService,
+          useClass: MockedGetCommitteePetitionService,
+        },
+      ],
+    }).compileComponents();
 
+    component = TestBed.inject(EditPetitionComponent);
+    _getCommitteePetitionService = TestBed.inject(GetCommitteePetitionService);
     fixture = TestBed.createComponent(EditPetitionComponent);
-    component = fixture.componentInstance;
+    component.ngOnInit();
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('issue', () => {
+    _getCommitteePetitionService.success$.subscribe((_) => {
+      const issue_element = fixture.debugElement.nativeElement.querySelectorAll(
+        'dp-edit-petition-issue'
+      );
+
+      fixture.detectChanges();
+      expect(issue_element.length).toEqual(1);
+    });
+    fixture.detectChanges();
   });
 });

--- a/src/app/features/edit-petition/edit-petition.component.spec.ts
+++ b/src/app/features/edit-petition/edit-petition.component.spec.ts
@@ -182,7 +182,7 @@ describe('EditPetitionComponent', () => {
 
     component.ngOnInit();
 
-    expect(getPetitionSpy).toHaveBeenCalledOnceWith('1');
+    expect(getPetitionSpy).toHaveBeenCalledOnceWith(mockedIssue.PK);
   });
 });
 

--- a/src/app/features/edit-petition/edit-petition.component.ts
+++ b/src/app/features/edit-petition/edit-petition.component.ts
@@ -1,22 +1,8 @@
-import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import {
-  BehaviorSubject,
-  Observable,
-  shareReplay,
-  Subject,
-  Subscription,
-  takeUntil,
-  tap,
-} from 'rxjs';
+import { map, Observable, Subject, takeUntil, tap } from 'rxjs';
 import { CandidatePetition, IssuePetition } from 'src/app/core/api/API';
-import { GetPublicPetitionService } from 'src/app/logic/petition/exports';
 import { GetCommitteePetitionService } from 'src/app/logic/petition/get-committee-petition.service';
-import {
-  CandidatePetitionData,
-  IssuePetitionData,
-  Result,
-} from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 
 @Component({
@@ -24,13 +10,16 @@ import { ResponsePetition } from 'src/app/shared/models/petition/response-petiti
   templateUrl: './edit-petition.component.html',
   providers: [GetCommitteePetitionService],
 })
-export class EditPetitionComponent implements OnInit {
-  public success$!: Observable<ResponsePetition | undefined>;
+export class EditPetitionComponent implements OnInit, OnDestroy {
+  protected success$!: Observable<ResponsePetition | undefined>;
   protected loading$!: Observable<boolean>;
   protected error$!: Observable<string | undefined>;
   protected result!: boolean;
+  protected id?: string;
 
   protected dataResponse: ResponsePetition = {};
+
+  private _unsubscribeAll = new Subject<void>();
 
   constructor(
     private _editPetitionLogic: GetCommitteePetitionService,
@@ -42,20 +31,30 @@ export class EditPetitionComponent implements OnInit {
     this.success$ = this._editPetitionLogic.success$;
     this.loading$ = this._editPetitionLogic.loading$;
     this.error$ = this._editPetitionLogic.error$;
-    this._editPetitionLogic.getPetition(
-      this._activatedRoute.snapshot.params['id']
-    );
-    this.success$.subscribe();
+
+    this._activatedRoute.paramMap
+      .pipe(
+        takeUntil(this._unsubscribeAll),
+        map((params) => params.get('id')!),
+        tap((id) => (this.id = id))
+      )
+      .subscribe((id) => this._editPetitionLogic.getPetition(id));
   }
+
+  ngOnDestroy(): void {
+    this._unsubscribeAll.next();
+    this._unsubscribeAll.complete();
+  }
+
   cancel() {
-    this._router.navigate([
-      '/committee/home/' + this._activatedRoute.snapshot.params['id'],
-    ]);
+    this._router.navigate(['/committee/home/' + this.id]);
   }
+
   submitCandidate(data: CandidatePetition) {
     this.dataResponse.dataCandidate = data;
     this.result = true;
   }
+
   submitIssue(data: IssuePetition) {
     this.dataResponse.dataIssue = data;
     this.result = true;

--- a/src/app/features/edit-petition/edit-petition.module.ts
+++ b/src/app/features/edit-petition/edit-petition.module.ts
@@ -13,6 +13,8 @@ import { EditPetitionIssueModule } from './edit-petition-issue/edit-petition-iss
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatButtonModule } from '@angular/material/button';
 import { GetPublicPetitionService } from 'src/app/logic/petition/get-public-petition.service';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 
 @NgModule({
   declarations: [EditPetitionComponent],
@@ -29,7 +31,8 @@ import { GetPublicPetitionService } from 'src/app/logic/petition/get-public-peti
     MatIconModule,
     MatProgressBarModule,
     MatButtonModule,
+    LoadingBarModule,
+    ErrorMsgModule,
   ],
-  providers: [GetPublicPetitionService],
 })
 export class EditPetitionModule {}

--- a/src/app/features/edit-petition/edit-petition.module.ts
+++ b/src/app/features/edit-petition/edit-petition.module.ts
@@ -12,7 +12,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { EditPetitionIssueModule } from './edit-petition-issue/edit-petition-issue.module';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatButtonModule } from '@angular/material/button';
-import { GetPublicPetitionService } from 'src/app/logic/petition/get-public-petition.service';
 import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
 import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 

--- a/src/app/features/edit-petition/edit-result-petition/edit-result-petition.component.spec.ts
+++ b/src/app/features/edit-petition/edit-result-petition/edit-result-petition.component.spec.ts
@@ -1,4 +1,10 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { RouterModule } from '@angular/router';
+import { PetitionStatus, PetitionType } from 'src/app/core/api/API';
+import { CutModule } from 'src/app/pipes/cut/cut.module';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
 
 import { EditResultPetitionComponent } from './edit-result-petition.component';
 
@@ -9,6 +15,13 @@ describe('ResultPetitionComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [EditResultPetitionComponent],
+      imports: [
+        CommonModule,
+        BasicCardModule,
+        MatButtonModule,
+        RouterModule,
+        CutModule,
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EditResultPetitionComponent);
@@ -18,5 +31,79 @@ describe('ResultPetitionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display the data corresponding to a petition of type candidate when receiving an object of type candidate', () => {
+    component.data = {
+      dataCandidate: {
+        __typename: 'CandidatePetition',
+        address: {
+          __typename: 'AddressData',
+          address: 'Some Site',
+          state: 'AL',
+          city: 'Some city',
+          number: '12',
+          zipCode: '000000',
+        },
+        createdAt: '00/00/0000',
+        PK: '',
+        name: 'May',
+        office: 'Office-1',
+        owner: '',
+        party: 'Party-1',
+        signatures: {
+          __typename: 'SignatureConnection',
+          items: [],
+          token: undefined,
+        },
+        status: PetitionStatus.ACTIVE,
+        type: PetitionType.CANDIDATE,
+        updatedAt: '',
+        version: 0,
+      },
+    };
+    fixture.detectChanges();
+    expect();
+    const element_p = fixture.debugElement.nativeElement.querySelectorAll('p');
+    expect(element_p.length).toBe(8);
+    expect(element_p[1].textContent).toContain('May');
+    expect(element_p[3].textContent).toContain('Office-1');
+    expect(element_p[5].textContent).toContain('Party-1');
+    const element_span =
+      fixture.debugElement.nativeElement.querySelectorAll('span');
+    expect(element_span.length).toBe(8);
+    expect(element_span[0].textContent).toContain('Address: Some Site');
+    expect(element_span[1].textContent).toContain('Number: 12');
+    expect(element_span[2].textContent).toContain('City: Some city');
+    expect(element_span[3].textContent).toContain('State: AL');
+    expect(element_span[4].textContent).toContain('Zip Code: 000000');
+  });
+
+  it('should display the data corresponding to a petition of type issue when receiving an object of type issue', () => {
+    component.data = {
+      dataIssue: {
+        __typename: 'IssuePetition',
+        createdAt: '00/00/0000',
+        PK: '',
+        detail: 'Text',
+        title: 'Title',
+        owner: '',
+        signatures: {
+          __typename: 'SignatureConnection',
+          items: [],
+          token: undefined,
+        },
+        status: PetitionStatus.ACTIVE,
+        type: PetitionType.CANDIDATE,
+        updatedAt: '',
+        version: 0,
+      },
+    };
+    fixture.detectChanges();
+    expect();
+    const element_p = fixture.debugElement.nativeElement.querySelectorAll('p');
+    expect(element_p.length).toBe(4);
+    expect(element_p[1].textContent).toContain(' Title ');
+    expect(element_p[3].textContent).toContain(' Text ');
   });
 });

--- a/src/app/features/home/home.component.html
+++ b/src/app/features/home/home.component.html
@@ -13,7 +13,7 @@
         class="md:hidden flex"
         [filterName]="'Filter by Category'"
         [filterType]="filterByCategory"
-        [disabled]="!!(loading$ | async)"
+        [disabled]="!!(loading$ | async) || items.length === 0 || !items"
         (event)="filter($event)"
       ></dp-filter-by-category>
       <dp-error-msg
@@ -65,7 +65,7 @@
       <dp-filter-by-category
         [filterName]="'Filter by Category'"
         [filterType]="filterByCategory"
-        [disabled]="!!(loading$ | async)"
+        [disabled]="!!(loading$ | async) || items.length === 0 || !items"
         (event)="filter($event)"
       ></dp-filter-by-category>
     </div>

--- a/src/app/features/inactive-petitions/inactive-petitions.component.html
+++ b/src/app/features/inactive-petitions/inactive-petitions.component.html
@@ -28,14 +28,14 @@
           class="w-full"
           [filterName]="'Filter by Category'"
           [filterType]="filterByCategory"
-          [disabled]="!!(loading$ | async)"
+          [disabled]="!!(loading$ | async) || items.length === 0 || !items"
           (event)="filterCategory($event)"
         ></dp-filter-by-category>
         <dp-filter-by-status
           class="w-full"
           [filterName]="'Filter by Status'"
           [filterStatus]="filterByStatus"
-          [disabled]="!!(loading$ | async)"
+          [disabled]="!!(loading$ | async) || items.length === 0 || !items"
           (event)="filterStatus($event)"
         ></dp-filter-by-status>
       </div>
@@ -79,13 +79,13 @@
       <dp-filter-by-category
         [filterName]="'Filter by Category'"
         [filterType]="filterByCategory"
-        [disabled]="!!(loading$ | async)"
+        [disabled]="!!(loading$ | async) || items.length === 0 || !items"
         (event)="filterCategory($event)"
       ></dp-filter-by-category>
       <dp-filter-by-status
         [filterName]="'Filter by Status'"
         [filterStatus]="filterByStatus"
-        [disabled]="!!(loading$ | async)"
+        [disabled]="!!(loading$ | async) || items.length === 0 || !items"
         (event)="filterStatus($event)"
       ></dp-filter-by-status>
     </div>

--- a/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.ts
+++ b/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.component.ts
@@ -2,7 +2,10 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Observable, Subscription } from 'rxjs';
-import { TargetPetitionInput } from 'src/app/core/api/API';
+import {
+  ApprovePetitionInput,
+  TargetPetitionInput,
+} from 'src/app/core/api/API';
 import { ApprovePetitionService } from 'src/app/logic/petition/approve-petition.service';
 import { DialogResultComponent } from 'src/app/shared/dialog-result/dialog-result.component';
 import { ApproveAlertComponent } from '../approve-alert/approve-alert.component';
@@ -10,6 +13,7 @@ import { ApproveAlertComponent } from '../approve-alert/approve-alert.component'
 @Component({
   selector: 'dp-aprove-dialog',
   templateUrl: './approve-dialog.component.html',
+  providers: [ApprovePetitionService],
 })
 export class ApproveDialogComponent implements OnInit {
   protected formGroup: FormGroup;
@@ -23,11 +27,11 @@ export class ApproveDialogComponent implements OnInit {
     private _fb: FormBuilder,
     private _approvePetitionLogic: ApprovePetitionService,
     @Inject(MAT_DIALOG_DATA)
-    public data: TargetPetitionInput
+    public data: ApprovePetitionInput
   ) {
     this.formGroup = this._fb.group({
       deadline: ['', [Validators.required]],
-      signatures: ['', [Validators.required]],
+      signatures: ['', [Validators.required, Validators.pattern('[0-9]')]],
     });
   }
 
@@ -51,6 +55,8 @@ export class ApproveDialogComponent implements OnInit {
 
   submit() {
     if (this.formGroup.valid) {
+      this.data.deadline = this.formGroup.value.deadline;
+      this.data.requiredSignatures = this.formGroup.value.signatures;
       const dialogRef = this._dialog.open(ApproveAlertComponent, {
         width: '480px',
       });

--- a/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.module.ts
+++ b/src/app/features/view-petition-city-staff/approve-dialog/approve-dialog.module.ts
@@ -32,6 +32,5 @@ import { ApprovePetitionService } from 'src/app/logic/petition/approve-petition.
     MatProgressBarModule,
   ],
   exports: [ApproveDialogComponent],
-  providers: [ApprovePetitionService],
 })
 export class ApproveDialogModule {}

--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.html
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.html
@@ -1,4 +1,4 @@
-<dp-basic-alert (event)="submit()">
+<dp-basic-alert>
   <ng-container modal-title
     >Are you sure you want to withdrawl this petition?</ng-container
   >

--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.spec.ts
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertWithdrawlPetitionComponent } from './alert-withdrawl-petition.component';
 
-describe('ConfirmEditPetitionComponent', () => {
+describe('AlertWithdrawlPetitionComponent', () => {
   let component: AlertWithdrawlPetitionComponent;
   let fixture: ComponentFixture<AlertWithdrawlPetitionComponent>;
 
@@ -18,5 +18,24 @@ describe('ConfirmEditPetitionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('evaluates that the "dp-basic-alert" component exists', () => {
+    const element =
+      fixture.debugElement.nativeElement.querySelector('dp-basic-alert');
+    expect(element).toBeTruthy();
+  });
+
+  it('evaluates that there are two buttons', () => {
+    const element =
+      fixture.debugElement.nativeElement.querySelectorAll('button');
+    expect(element.length).toBe(2);
+  });
+
+  it('check that the alert message exists', () => {
+    const element = fixture.debugElement.nativeElement.querySelectorAll('p');
+    expect(element[0].textContent).toEqual(
+      'Once this has been withdrawn it can not be undone'
+    );
   });
 });

--- a/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.ts
+++ b/src/app/features/view-petition-committee/alert-withdrawl-petition/alert-withdrawl-petition.component.ts
@@ -4,10 +4,6 @@ import { Component, OnInit } from '@angular/core';
   selector: 'dp-alert-withdrawl-petition',
   templateUrl: './alert-withdrawl-petition.component.html',
 })
-export class AlertWithdrawlPetitionComponent implements OnInit {
+export class AlertWithdrawlPetitionComponent {
   constructor() {}
-
-  ngOnInit(): void {}
-
-  submit() {}
 }

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.html
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.html
@@ -4,52 +4,32 @@
   >
   <span modal-body class="w-full flex flex-col gap-6">
     <p>Once this has been withdrawn it can not be undone</p>
-    <ng-container [ngSwitch]="currentStep$ | async">
-      <ng-container *ngSwitchCase="'loading'">
-        <div class="flex justify-center w-full">
-          <h3 class="leading-7 font-extrabold">Loading</h3>
-        </div>
 
-        <mat-progress-bar
-          mode="indeterminate"
-          color="primary"
-        ></mat-progress-bar>
-      </ng-container>
-      <ng-container class="flex" *ngSwitchCase="'error'">
-        <div class="flex justify-center w-full">
-          <h3 class="leading-7 font-extrabold">An error has occurred</h3>
-        </div>
+    <dp-error-msg
+      *ngIf="!(loading$ | async) && (error$ | async) as error"
+      [error]="error"
+    >
+    </dp-error-msg>
+    <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
 
-        <div class="flex flex-row items-center justify-center">
-          <mat-icon
-            class="w-[14px] h-[14px]"
-            [svgIcon]="'custom_icons:c_close'"
-          ></mat-icon>
-          <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
-        </div>
-      </ng-container>
-
-      <ng-container class="flex" *ngSwitchCase="'contents'">
-        <form [formGroup]="formGroup" class="w-full grid grid-cols-1 gap-6">
-          <mat-form-field>
-            <mat-label>Type "YES" to confirm</mat-label>
-            <input type="text" matInput formControlName="code" />
-            <mat-error *ngIf="this.formGroup.get('code')?.errors?.['required']">
-              <div class="flex flex-row items-center">
-                <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
-                <span class="ml-[9px]">This field is required</span>
-              </div>
-            </mat-error>
-            <mat-error *ngIf="this.formGroup.get('code')?.errors?.['pattern']">
-              <div class="flex flex-row items-center">
-                <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
-                <span class="ml-[9px]">type "YES" to confirm</span>
-              </div>
-            </mat-error>
-          </mat-form-field>
-        </form>
-      </ng-container>
-    </ng-container>
+    <form [formGroup]="formGroup" class="w-full grid grid-cols-1 gap-6">
+      <mat-form-field>
+        <mat-label>Type "YES" to confirm</mat-label>
+        <input type="text" matInput formControlName="code" />
+        <mat-error *ngIf="this.formGroup.get('code')?.errors?.['required']">
+          <div class="flex flex-row items-center">
+            <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
+            <span class="ml-[9px]">This field is required</span>
+          </div>
+        </mat-error>
+        <mat-error *ngIf="this.formGroup.get('code')?.errors?.['pattern']">
+          <div class="flex flex-row items-center">
+            <mat-icon [svgIcon]="'custom_icons:c_close'"></mat-icon>
+            <span class="ml-[9px]">type "YES" to confirm</span>
+          </div>
+        </mat-error>
+      </mat-form-field>
+    </form>
 
     <div class="flex flex-col w-full gap-4">
       <button

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.spec.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.spec.ts
@@ -1,14 +1,54 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BasicAlertModule } from 'src/app/shared/basic-alert/basic-alert.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
 
 import { ConfirmWithdrawlPetitionComponent } from './confirm-withdrawl-petition.component';
 
-describe('ConfirmEditPetitionComponent', () => {
+describe('ConfirmWithdrawlPetitionComponent', () => {
   let component: ConfirmWithdrawlPetitionComponent;
   let fixture: ComponentFixture<ConfirmWithdrawlPetitionComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ConfirmWithdrawlPetitionComponent],
+      imports: [
+        CommonModule,
+        BasicAlertModule,
+        MatButtonModule,
+        MatDialogModule,
+        MatInputModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatIconModule,
+        MatProgressBarModule,
+        BrowserAnimationsModule,
+        LoadingBarModule,
+        ErrorMsgModule,
+      ],
+      providers: [
+        ConfirmWithdrawlPetitionComponent,
+        {
+          provide: MatDialogRef,
+          useValue: {},
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { data: { id: 1 } },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ConfirmWithdrawlPetitionComponent);
@@ -18,5 +58,29 @@ describe('ConfirmEditPetitionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('evaluates that the "dp-basic-alert" component exists', () => {
+    const element =
+      fixture.debugElement.nativeElement.querySelector('dp-basic-alert');
+    expect(element).toBeTruthy();
+  });
+
+  it('evaluates that there are three buttons', () => {
+    const element =
+      fixture.debugElement.nativeElement.querySelectorAll('button');
+    expect(element.length).toBe(3);
+  });
+
+  it('check that the alert message exists', () => {
+    const element = fixture.debugElement.nativeElement.querySelectorAll('p');
+    expect(element[0].textContent).toEqual(
+      'Once this has been withdrawn it can not be undone'
+    );
+  });
+
+  it('check that the form exists', () => {
+    const element = fixture.debugElement.nativeElement.querySelector('form');
+    expect(element).toBeTruthy();
   });
 });

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.component.ts
@@ -14,16 +14,12 @@ import { WithdrawPetitionService } from 'src/app/logic/petition/withdraw-petitio
 @Component({
   selector: 'dp-confirm-withdrawl-petition',
   templateUrl: './confirm-withdrawl-petition.component.html',
+  providers: [WithdrawPetitionService],
 })
 export class ConfirmWithdrawlPetitionComponent implements OnInit {
-  protected result$!: Subscription;
-  protected error: string | undefined;
+  protected error$!: Observable<string | undefined>;
   protected loading$!: Observable<boolean>;
-  protected currentStep$: BehaviorSubject<
-    'loading' | 'empty' | 'contents' | 'error'
-  > = new BehaviorSubject<'loading' | 'empty' | 'contents' | 'error'>(
-    'contents'
-  );
+
   public formGroup: FormGroup;
   constructor(
     private _fb: FormBuilder,
@@ -40,20 +36,14 @@ export class ConfirmWithdrawlPetitionComponent implements OnInit {
     });
   }
   ngOnInit(): void {
-    this.result$ = this._withdrawlLogic.result$.subscribe((result) => {
-      if (!!result.result) {
-        this._router.navigate(['/committee/home', this.data.id, result.result]);
-        this._dialog.closeAll();
-      } else {
-        this.error = result.error;
-        this.currentStep$.next('error');
-      }
+    this._withdrawlLogic.success$.subscribe((result) => {
+      this._router.navigate(['/committee/home', this.data.id, result]);
+      this._dialog.closeAll();
     });
     this.loading$ = this._withdrawlLogic.loading$;
   }
 
   submit() {
-    this.currentStep$.next('loading');
     this._withdrawlLogic.withdrawPetition(this.data.id);
   }
 }

--- a/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.module.ts
+++ b/src/app/features/view-petition-committee/confirm-withdrawl-petition/confirm-withdrawl-petition.module.ts
@@ -9,6 +9,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { WithdrawPetitionService } from 'src/app/logic/petition/withdraw-petition.service';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 
 @NgModule({
   declarations: [ConfirmWithdrawlPetitionComponent],
@@ -22,8 +24,9 @@ import { WithdrawPetitionService } from 'src/app/logic/petition/withdraw-petitio
     ReactiveFormsModule,
     MatIconModule,
     MatProgressBarModule,
+    LoadingBarModule,
+    ErrorMsgModule,
   ],
   exports: [ConfirmWithdrawlPetitionComponent],
-  providers: [WithdrawPetitionService],
 })
 export class ConfirmWithdrawlPetitionModule {}

--- a/src/app/features/view-petition-committee/current-result/current-result.component.html
+++ b/src/app/features/view-petition-committee/current-result/current-result.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="signatureSummary"
+  *ngIf="status !== 'NEW' && signatureSummary"
   class="flex flex-col gap-4 rounded-xl p-4 bg-[#FFFFFF] border border-[#D7D7D7] shadow-sm"
 >
   <div class="flex flex-row justify-between">
@@ -39,7 +39,7 @@
 </div>
 <!--STATUS:NEW-->
 <div
-  *ngIf="!signatureSummary"
+  *ngIf="status === 'NEW'"
   class="flex flex-col gap-4 rounded-xl p-4 bg-[#FFFFFF] border border-[#D7D7D7] shadow-sm"
 >
   <div class="flex flex-row justify-between">

--- a/src/app/features/view-petition-committee/current-result/current-result.component.spec.ts
+++ b/src/app/features/view-petition-committee/current-result/current-result.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PetitionStatus, PetitionType } from 'src/app/core/api/API';
 
 import { CurrentResultComponent } from './current-result.component';
 
@@ -8,9 +9,8 @@ describe('CurrentResultComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ CurrentResultComponent ]
-    })
-    .compileComponents();
+      declarations: [CurrentResultComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CurrentResultComponent);
     component = fixture.componentInstance;
@@ -19,5 +19,67 @@ describe('CurrentResultComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('evaluates to show the signature value if the petition status is NEW', () => {
+    component.data = {
+      dataIssue: {
+        __typename: 'IssuePetition',
+        PK: '',
+        createdAt: '',
+        detail: '',
+        owner: '',
+        signatures: {
+          __typename: 'SignatureConnection',
+          items: [],
+          token: undefined,
+        },
+        status: PetitionStatus.NEW,
+        title: '',
+        type: PetitionType.ISSUE,
+        updatedAt: '',
+        version: 0,
+      },
+    };
+    component.ngOnChanges();
+    fixture.detectChanges();
+    const element = fixture.debugElement.nativeElement.querySelectorAll('p');
+    expect(element[4].textContent).toEqual('Pending');
+  });
+
+  it('evaluates to show the signature values if the petition status is different from NEW', () => {
+    component.data = {
+      dataIssue: {
+        __typename: 'IssuePetition',
+        PK: '',
+        createdAt: '',
+        detail: '',
+        owner: '',
+        signatures: {
+          __typename: 'SignatureConnection',
+          items: [],
+          token: undefined,
+        },
+        signatureSummary: {
+          __typename: 'SignatureSummary',
+          approved: 100,
+          required: 1000,
+          submitted: 150,
+          deadline: '00/00/0000',
+        },
+        status: PetitionStatus.ACTIVE,
+        title: '',
+        type: PetitionType.ISSUE,
+        updatedAt: '',
+        version: 0,
+      },
+    };
+    component.ngOnChanges();
+    fixture.detectChanges();
+    const element = fixture.debugElement.nativeElement.querySelectorAll('p');
+    expect(element[4].textContent).toEqual(' 100 ');
+    expect(element[6].textContent).toEqual(' 1000 ');
+    expect(element[8].textContent).toEqual(' 00/00/0000 ');
+    expect(element[2].textContent).toEqual(' 150 ');
   });
 });

--- a/src/app/features/view-petition-committee/current-result/current-result.component.ts
+++ b/src/app/features/view-petition-committee/current-result/current-result.component.ts
@@ -27,7 +27,7 @@ export class CurrentResultComponent implements OnInit, OnChanges {
     'h-[26px] bg-[#FF3030] px-4 py-1 text-black  rounded';
 
   constructor() {}
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes?: SimpleChanges): void {
     let { status } = this.data.dataCandidate
       ? this.data.dataCandidate
       : this.data.dataIssue
@@ -35,11 +35,8 @@ export class CurrentResultComponent implements OnInit, OnChanges {
       : { status: undefined };
     this.status = status;
 
-    let { signatureSummary } = this.data.dataCandidate
-      ? this.data.dataCandidate
-      : this.data.dataIssue
-      ? this.data.dataIssue
-      : { signatureSummary: undefined };
+    let { signatureSummary } = this.data.dataCandidate ??
+      this.data.dataIssue ?? { signatureSummary: undefined };
     this.signatureSummary = signatureSummary;
 
     if (status) {

--- a/src/app/features/view-petition-committee/view-petition-committee.component.html
+++ b/src/app/features/view-petition-committee/view-petition-committee.component.html
@@ -5,71 +5,52 @@
         [route]="'/committee/home'"
         [text]="'Back to Home'"
       ></dp-return-link>
-      <ng-container [ngSwitch]="currentStep$ | async">
-        <ng-container *ngSwitchCase="'contents'">
-          <div
-            class="flex flex-col md:flex-row justify-center gap-4"
-            *ngIf="petition"
-          >
-            <div [class]="StatusStyleCurrent">
-              <p
-                class="text-[14px] leading-[18px] font-bold text-[#FFFFFF] cursor-default"
-              >
-                {{ petition.status | petitionStatus }}
-              </p>
-            </div>
-            <button
-              mat-button
-              color="primary"
-              [disabled]="!(petition.status === 'NEW')"
-              [routerLink]="'/committee/edit-petition/' + id"
-            >
-              Edit
-            </button>
-            <button mat-flat-button color="primary" (click)="submit()">
-              Withdrawl
-            </button>
-          </div></ng-container
-        >
-      </ng-container>
-    </div>
-    <ng-container [ngSwitch]="currentStep$ | async">
-      <ng-container *ngSwitchCase="'loading'">
-        <div class="flex justify-center w-full">
-          <h3 class="leading-7 font-extrabold">Loading</h3>
-        </div>
-
-        <mat-progress-bar
-          mode="indeterminate"
-          color="primary"
-        ></mat-progress-bar>
-      </ng-container>
-      <ng-container class="flex" *ngSwitchCase="'error'">
-        <div class="flex justify-center w-full">
-          <h3 class="leading-7 font-extrabold">An error has occurred</h3>
-        </div>
-
-        <div class="flex flex-row items-center justify-center">
-          <mat-icon
-            class="w-[14px] h-[14px]"
-            [svgIcon]="'custom_icons:c_close'"
-          ></mat-icon>
-          <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
-        </div>
-      </ng-container>
-
-      <ng-container class="flex" *ngSwitchCase="'contents'">
+      <ng-container *ngIf="success$ | async">
         <div
-          class="flex flex-col-reverse md:flex-row justify-center gap-6 mt-4"
+          class="flex flex-col md:flex-row justify-center gap-4"
+          *ngIf="petition"
         >
-          <div class="flex flex-col gap-5 max-w-[791px] w-full">
-            <dp-petition-view [data]="resultData"></dp-petition-view>
+          <div [class]="StatusStyleCurrent">
+            <p
+              class="text-[14px] leading-[18px] font-bold text-[#FFFFFF] cursor-default"
+            >
+              {{ petition.status | petitionStatus }}
+            </p>
           </div>
-          <div class="max-w-[386px] w-full h-fit">
-            <dp-current-result [data]="resultData"></dp-current-result>
-          </div>
+          <button
+            mat-button
+            color="primary"
+            [disabled]="!(petition.status === 'NEW')"
+            [routerLink]="
+              '/committee/edit-petition/' +
+              _activatedRoute.snapshot.params['id']
+            "
+          >
+            Edit
+          </button>
+          <button mat-flat-button color="primary" (click)="submit()">
+            Withdrawl
+          </button>
+        </div></ng-container
+      >
+    </div>
+
+    <dp-error-msg
+      *ngIf="!(loading$ | async) && (error$ | async) as error"
+      [error]="error"
+    >
+    </dp-error-msg>
+    <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
+
+    <ng-container class="flex" *ngIf="success$ | async as resultData">
+      <div class="flex flex-col-reverse md:flex-row justify-center gap-6 mt-4">
+        <div class="flex flex-col gap-5 max-w-[791px] w-full">
+          <dp-petition-view [data]="resultData"></dp-petition-view>
         </div>
-      </ng-container>
+        <div class="max-w-[386px] w-full h-fit">
+          <dp-current-result [data]="resultData"></dp-current-result>
+        </div>
+      </div>
     </ng-container>
   </div>
 </div>

--- a/src/app/features/view-petition-committee/view-petition-committee.component.html
+++ b/src/app/features/view-petition-committee/view-petition-committee.component.html
@@ -21,10 +21,7 @@
             mat-button
             color="primary"
             [disabled]="!(petition.status === 'NEW')"
-            [routerLink]="
-              '/committee/edit-petition/' +
-              _activatedRoute.snapshot.params['id']
-            "
+            [routerLink]="'/committee/edit-petition/' + id"
           >
             Edit
           </button>

--- a/src/app/features/view-petition-committee/view-petition-committee.component.spec.ts
+++ b/src/app/features/view-petition-committee/view-petition-committee.component.spec.ts
@@ -1,6 +1,21 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { PetitionStatusModule } from 'src/app/pipes/petition-status/petition-status.module';
+import { PetitionViewModule } from 'src/app/shared/petition-view/petition-view.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { AlertWithdrawlPetitionModule } from './alert-withdrawl-petition/alert-withdrawl-petition.module';
+import { ConfirmWithdrawlPetitionModule } from './confirm-withdrawl-petition/confirm-withdrawl-petition.module';
+import { CurrentResultModule } from './current-result/current-result.module';
+import { ViewPetitionCommitteeRoutingModule } from './view-petition-committee-routing.module';
 
 import { ViewPetitionCommitteeComponent } from './view-petition-committee.component';
+import { WithdrawlResultModule } from './withdrawl-result/withdrawl-result.module';
 
 describe('ViewPetitionCommitteeComponent', () => {
   let component: ViewPetitionCommitteeComponent;
@@ -8,9 +23,30 @@ describe('ViewPetitionCommitteeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ViewPetitionCommitteeComponent ]
-    })
-    .compileComponents();
+      declarations: [ViewPetitionCommitteeComponent],
+      imports: [
+        CommonModule,
+        ViewPetitionCommitteeRoutingModule,
+        MatProgressBarModule,
+        MatIconModule,
+        PetitionViewModule,
+        ReturnLinkModule,
+        CurrentResultModule,
+        MatButtonModule,
+        AlertWithdrawlPetitionModule,
+        ConfirmWithdrawlPetitionModule,
+        MatDialogModule,
+        RouterTestingModule,
+        WithdrawlResultModule,
+        PetitionStatusModule,
+      ],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ViewPetitionCommitteeComponent);
     component = fixture.componentInstance;
@@ -18,6 +54,32 @@ describe('ViewPetitionCommitteeComponent', () => {
   });
 
   it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should create', () => {
+    const element =
+      fixture.debugElement.nativeElement.querySelectorAll('button');
+    expect(element.length).toEqual(2);
+  });
+
+  it('should create', () => {
+    //return link
+    expect(component).toBeTruthy();
+  });
+
+  it('should create', () => {
+    // un petition card
+    expect(component).toBeTruthy();
+  });
+
+  it('should create', () => {
+    //un current result
+    expect(component).toBeTruthy();
+  });
+
+  it('should create', () => {
+    //si es new decir awaiting aproval
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/features/view-petition-committee/view-petition-committee.module.ts
+++ b/src/app/features/view-petition-committee/view-petition-committee.module.ts
@@ -15,6 +15,8 @@ import { RouterModule } from '@angular/router';
 import { ConfirmWithdrawlPetitionModule } from './confirm-withdrawl-petition/confirm-withdrawl-petition.module';
 import { WithdrawlResultModule } from './withdrawl-result/withdrawl-result.module';
 import { PetitionStatusModule } from 'src/app/pipes/petition-status/petition-status.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
 
 @NgModule({
   declarations: [ViewPetitionCommitteeComponent],
@@ -33,6 +35,8 @@ import { PetitionStatusModule } from 'src/app/pipes/petition-status/petition-sta
     RouterModule,
     WithdrawlResultModule,
     PetitionStatusModule,
+    LoadingBarModule,
+    ErrorMsgModule,
   ],
 })
 export class ViewPetitionCommitteeModule {}

--- a/src/app/logic/petition/get-committee-petition.service.spec.ts
+++ b/src/app/logic/petition/get-committee-petition.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GetPublicPetitionService } from './get-public-petition.service';
+
+describe('EditPetitionService', () => {
+  let service: GetPublicPetitionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GetPublicPetitionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/logic/petition/get-committee-petition.service.ts
+++ b/src/app/logic/petition/get-committee-petition.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import {
+  exhaustMap,
+  map,
+  merge,
+  Observable,
+  partition,
+  ReplaySubject,
+  shareReplay,
+  Subject,
+  tap,
+} from 'rxjs';
+import { LoggingService } from 'src/app/core/logging/loggin.service';
+
+import { Result } from 'src/app/shared/models/exports';
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+import { PetitionService } from './exports';
+
+@Injectable()
+export class GetCommitteePetitionService {
+  public error$: Observable<string | undefined>;
+  public success$: Observable<ResponsePetition | undefined>;
+  public loading$: Observable<boolean>;
+  public result$: Observable<Result<ResponsePetition>>;
+  private submit$: ReplaySubject<string> = new ReplaySubject();
+
+  constructor(
+    private _petitionService: PetitionService,
+    private _loggingService: LoggingService
+  ) {
+    this.result$ = this.submit$.pipe(
+      exhaustMap((data) => this._petitionService.getCommitteePetition(data)),
+      shareReplay(1)
+    );
+    const [success$, error$] = partition(this.result$, (value) =>
+      value.result ? true : false
+    );
+
+    this.success$ = success$.pipe(
+      map((value) => value.result),
+      tap((value) => this._loggingService.log(value)),
+      shareReplay(1)
+    );
+
+    this.error$ = error$.pipe(
+      map((value) => value.error),
+      tap((value) => this._loggingService.log(value)),
+      shareReplay(1)
+    );
+
+    const end$ = merge(this.success$, this.error$);
+
+    this.loading$ = merge(
+      this.submit$.pipe(
+        map((v) => true),
+        tap(() => console.log('start'))
+      ),
+      end$.pipe(
+        map((v) => false),
+        tap(() => console.log('end'))
+      )
+    ).pipe(shareReplay(1));
+  }
+  ngOnDestroy(): void {
+    this.submit$.complete();
+  }
+
+  /** This method begins the process of obtaining a petitions
+  @param id: The requested request ID
+  */
+
+  getPetition(id: string) {
+    this.submit$.next(id);
+  }
+}

--- a/src/app/logic/petition/get-committee-petition.service.ts
+++ b/src/app/logic/petition/get-committee-petition.service.ts
@@ -7,7 +7,6 @@ import {
   partition,
   ReplaySubject,
   shareReplay,
-  Subject,
   tap,
 } from 'rxjs';
 import { LoggingService } from 'src/app/core/logging/loggin.service';

--- a/src/app/shared/petition-card/petition-card.component.html
+++ b/src/app/shared/petition-card/petition-card.component.html
@@ -17,9 +17,15 @@
         </p>
       </div>
     </div>
-    <h3 *ngIf="disabled; else titleLink" class="flex leading-7 font-extrabold">
-      {{ issue.title }}
-    </h3>
+    <div class="w-fit">
+      <h3
+        *ngIf="disabled; else titleLink"
+        class="flex leading-7 font-extrabold"
+      >
+        {{ issue.title }}
+      </h3>
+    </div>
+
     <ng-template #titleLink
       ><h3
         class="flex leading-7 font-extrabold cursor-pointer"
@@ -90,9 +96,15 @@
         </p>
       </div>
     </div>
-    <h3 *ngIf="disabled; else titleLink" class="flex leading-7 font-extrabold">
-      {{ candidate.name }}
-    </h3>
+    <div class="w-fit">
+      <h3
+        *ngIf="disabled; else titleLink"
+        class="flex leading-7 font-extrabold"
+      >
+        {{ candidate.name }}
+      </h3>
+    </div>
+
     <ng-template #titleLink
       ><h3
         class="flex leading-7 font-extrabold cursor-pointer"

--- a/src/testing/activated-route-stub.ts
+++ b/src/testing/activated-route-stub.ts
@@ -1,0 +1,24 @@
+import { convertToParamMap, ParamMap, Params } from '@angular/router';
+import { ReplaySubject } from 'rxjs';
+
+/**
+ * An ActivateRoute test double with a `paramMap` observable.
+ * Use the `setParamMap()` method to add the next `paramMap` value.
+ */
+export class ActivatedRouteStub {
+  // Use a ReplaySubject to share last value with subscribers
+  // and pump new values into the `paramMap` observable
+  private subject = new ReplaySubject<ParamMap>(1);
+
+  constructor(initialParams?: Params) {
+    this.setParamMap(initialParams);
+  }
+
+  /** The mock paramMap observable */
+  readonly paramMap = this.subject.asObservable();
+
+  /** Set the paramMap observable's next value */
+  setParamMap(params: Params = {}) {
+    this.subject.next(convertToParamMap(params));
+  }
+}


### PR DESCRIPTION
Problem: Design and implement unit tests of the function of editing petition (committee)
Description: Design and implement the unit tests belonging to the components alert-withdrawl-petition, confirm-withdrawl-petition, current-result, withdrawl-result, view-petition-committee  and achieve a coverage greater than 80%Design and implement the unit tests of the function view details a petition (home)

Solution:
Add unit tests for alert-withdrawl-petition
Add unit tests for iew-petition-committee