### PR TITLE
DP-246 Design and implement unit tests of the list petition function committee

### DIFF
--- a/src/app/features/committee-home/committee-home.component.spec.ts
+++ b/src/app/features/committee-home/committee-home.component.spec.ts
@@ -1,23 +1,288 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { ActivatedRoute, RouterLink, RouterModule } from '@angular/router';
+import { GetPetitionsCommitteeService } from 'src/app/logic/committee/getPetitionsCommitteeService.service';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { PetitionCardModule } from 'src/app/shared/petition-card/petition-card.module';
+import { CommitteeHomeRoutingModule } from './committee-home-routing.module';
+import { Observable, of } from 'rxjs';
 import { CommitteeHomeComponent } from './committee-home.component';
+import {
+  CandidatePetition,
+  IssuePetition,
+  PetitionsByOwnerInput,
+  PetitionStatus,
+  PetitionType,
+} from 'src/app/core/api/API';
+import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BufferPetition } from 'src/app/shared/models/petition/buffer-petitions';
 
 describe('CommitteeHomeComponent', () => {
   let component: CommitteeHomeComponent;
   let fixture: ComponentFixture<CommitteeHomeComponent>;
+  let _getPetitionsCommitteeService: GetPetitionsCommitteeService;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ CommitteeHomeComponent ]
+    TestBed.configureTestingModule({
+      declarations: [CommitteeHomeComponent],
+      imports: [
+        CommonModule,
+        CommitteeHomeRoutingModule,
+        MatButtonModule,
+        RouterModule,
+        PetitionCardModule,
+        MatIconModule,
+        MatProgressBarModule,
+        LoadingBarModule,
+        ErrorMsgModule,
+        BrowserAnimationsModule,
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
     })
-    .compileComponents();
+      .overrideComponent(CommitteeHomeComponent, {
+        set: {
+          providers: [
+            {
+              provide: GetPetitionsCommitteeService,
+              useClass: MockedGetPetitionsCommitteeService,
+            },
+          ],
+        },
+      })
+      .compileComponents();
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(CommitteeHomeComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    _getPetitionsCommitteeService = fixture.debugElement.injector.get(
+      GetPetitionsCommitteeService
+    );
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should show the loading bar when the petition is loading', () => {
+    component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpLoadingBars =
+      fixture.debugElement.nativeElement.querySelectorAll('dp-loading-bar');
+
+    expect(dpLoadingBars.length).toBe(1);
+  });
+
+  it('should not show the loading bar if the petition is not loading', () => {
+    spyOnProperty(
+      _getPetitionsCommitteeService,
+      'loading$',
+      'get'
+    ).and.returnValue(of(false));
+
+    component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpLoadingBars =
+      fixture.debugElement.nativeElement.querySelectorAll('dp-loading-bar');
+
+    expect(dpLoadingBars.length).toBe(0);
+  });
+
+  it('should show 6 petition card elements when a successful response is received', () => {
+    //component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpPetitionCard =
+      fixture.debugElement.nativeElement.querySelectorAll('dp-petition-card');
+
+    expect(dpPetitionCard.length).toBe(6);
+  });
+
+  it('should show 12 petition card elements when a "see more" button is clicked', () => {
+    //component.ngOnInit();
+
+    fixture.detectChanges();
+    component.pageNumber();
+
+    const dpPetitionCard =
+      fixture.debugElement.nativeElement.querySelectorAll('dp-petition-card');
+
+    expect(dpPetitionCard.length).toBe(12);
+  });
+
+  it('should show the message " You still have no petitions " when there are no elements in a successful response', () => {
+    spyOnProperty(
+      _getPetitionsCommitteeService,
+      'success$',
+      'get'
+    ).and.returnValue(
+      of({
+        items: [],
+        cursor: undefined,
+      })
+    );
+
+    fixture.detectChanges();
+
+    const element = fixture.debugElement.nativeElement.querySelectorAll('h3');
+
+    expect(element[1].textContent).toEqual(' You still have no petitions ');
+  });
+
+  it('should show 8 buttons when a successful response is received', () => {
+    //component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpPetitionCard =
+      fixture.debugElement.nativeElement.querySelectorAll('button');
+
+    expect(dpPetitionCard.length).toBe(8);
+  });
+
+  it('should show a "see more" button when cursor value', () => {
+    //component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpPetitionCard =
+      fixture.debugElement.nativeElement.querySelectorAll('button');
+
+    expect(dpPetitionCard[6].textContent).toEqual(' See More ');
+  });
+
+  it('should show the error element if an error ocurred and is not loading', () => {
+    spyOnProperty(
+      _getPetitionsCommitteeService,
+      'error$',
+      'get'
+    ).and.returnValue(of('error'));
+
+    spyOnProperty(
+      _getPetitionsCommitteeService,
+      'loading$',
+      'get'
+    ).and.returnValue(of(false));
+
+    component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpErrorMsg =
+      fixture.debugElement.nativeElement.querySelectorAll('dp-error-msg');
+
+    expect(dpErrorMsg.length).toBe(1);
+  });
+
+  it('should not show the error element if an error ocurred and the component is loading', () => {
+    spyOnProperty(
+      _getPetitionsCommitteeService,
+      'error$',
+      'get'
+    ).and.returnValue(of('error'));
+
+    spyOnProperty(
+      _getPetitionsCommitteeService,
+      'loading$',
+      'get'
+    ).and.returnValue(of(true));
+
+    component.ngOnInit();
+
+    fixture.detectChanges();
+
+    const dpErrorMsg =
+      fixture.debugElement.nativeElement.querySelectorAll('dp-error-msg');
+
+    expect(dpErrorMsg.length).toBe(0);
+  });
+
+  //evaluar que no muestre show moreç
+  //evaluar que muestre estoy vacio cuando este vacio
 });
+
+class MockedGetPetitionsCommitteeService {
+  public get error$(): Observable<string | undefined> {
+    return of(undefined);
+  }
+
+  public get success$(): Observable<BufferPetition | undefined> {
+    return of({
+      items: [
+        { dataIssue: mockedIssue },
+        { dataCandidate: mockedCandiadate },
+        { dataIssue: mockedIssue },
+        { dataCandidate: mockedCandiadate },
+        { dataIssue: mockedIssue },
+        { dataCandidate: mockedCandiadate },
+      ],
+      cursor: '1',
+    });
+  }
+
+  public get loading$(): Observable<boolean> {
+    return of(true);
+  }
+
+  getPetitions(data: PetitionsByOwnerInput): void {}
+}
+
+const mockedIssue: IssuePetition = {
+  __typename: 'IssuePetition',
+  PK: '1',
+  createdAt: '',
+  detail: 'Text',
+  owner: '',
+  signatures: {
+    __typename: 'SignatureConnection',
+    items: [],
+    token: undefined,
+  },
+  status: PetitionStatus.NEW,
+  title: 'Title',
+  type: PetitionType.ISSUE,
+  updatedAt: '',
+  version: 0,
+};
+
+const mockedCandiadate: CandidatePetition = {
+  __typename: 'CandidatePetition',
+  PK: '',
+  address: {
+    __typename: 'AddressData',
+    address: '',
+    city: undefined,
+    number: undefined,
+    state: '',
+    zipCode: undefined,
+  },
+  createdAt: '',
+  name: '',
+  office: '',
+  owner: '',
+  party: '',
+  signatures: {
+    __typename: 'SignatureConnection',
+    items: [],
+    token: undefined,
+  },
+  status: PetitionStatus.ACTIVE,
+  type: PetitionType.CANDIDATE,
+  updatedAt: '',
+  version: 0,
+};


### PR DESCRIPTION
Problem: Design and implement unit tests of the list petition function (committee)
Description: Evaluate the elements of the interface and the operation of the functions in the home-committee component.
Solution:
The unit tests for the home-committee component are evaluated:
[should show the message " You still have no petitions " when there are no elements in a successful response](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20show%20the%20message%20%22%20You%20still%20have%20no%20petitions%20%22%20when%20there%20are%20no%20elements%20in%20a%20successful%20response)
[should call getPetitions function when a "see more" button is clicked](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20call%20getPetitions%20function%20when%20a%20%22see%20more%22%20button%20is%20clicked)
[should show a "see more" button when cursor value](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20show%20a%20%22see%20more%22%20button%20when%20cursor%20value)
[should not show the error element if an error ocurred and the component is loading](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20not%20show%20the%20error%20element%20if%20an%20error%20ocurred%20and%20the%20component%20is%20loading)
[should create](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20create)
[should show 8 buttons when a successful response is received](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20show%208%20buttons%20when%20a%20successful%20response%20is%20received)
[should show the error element if an error ocurred and is not loading](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20show%20the%20error%20element%20if%20an%20error%20ocurred%20and%20is%20not%20loading)
[should not show the loading bar if the petition is not loading](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20not%20show%20the%20loading%20bar%20if%20the%20petition%20is%20not%20loading)
[should show the loading bar when the petition is loading](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20show%20the%20loading%20bar%20when%20the%20petition%20is%20loading)
[should show 6 petition card elements when a successful response is received](http://localhost:9876/context.html?spec=CommitteeHomeComponent%20should%20show%206%20petition%20card%20elements%20when%20a%20successful%20response%20is%20received)