### PR TITLE
DP-160 Integrate API endpoint with the ui to endorse now option

### DIFF
--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.component.html
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.component.html
@@ -12,25 +12,12 @@
       <dp-basic-card>
         <div class="w-full flex flex-col gap-[10px]">
           <p>Enter the code that was sent to you.</p>
-          <ng-container *ngIf="!(loading$ | async)">
-            <ng-container *ngIf="result$ | async as result">
-              <div
-                *ngIf="result.error as error"
-                class="flex flex-row items-center"
-              >
-                <mat-icon
-                  class="w-[14px] h-[14px]"
-                  [svgIcon]="'custom_icons:c_close'"
-                ></mat-icon>
-                <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
-              </div>
-            </ng-container>
-          </ng-container>
-          <mat-progress-bar
-            mode="indeterminate"
-            color="primary"
-            *ngIf="loading$ | async"
-          ></mat-progress-bar>
+          <dp-error-msg
+            *ngIf="!(loading$ | async) && (error$ | async) as error"
+            [error]="error"
+          >
+          </dp-error-msg>
+          <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
           <mat-form-field>
             <mat-label>Confirmation Code</mat-label>
             <input type="text" matInput formControlName="code" />

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.module.ts
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.module.ts
@@ -8,7 +8,6 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { ConfirmSignPetitionRoutingModule } from './confirm-sign-petition-routing.module';
 import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ConfirmSignPetitionService } from 'src/app/logic/petition/confirm-sign-petition.service';
 import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
 import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';

--- a/src/app/features/confirm-sign-petition/confirm-sign-petition.module.ts
+++ b/src/app/features/confirm-sign-petition/confirm-sign-petition.module.ts
@@ -10,6 +10,8 @@ import { ConfirmSignPetitionRoutingModule } from './confirm-sign-petition-routin
 import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ConfirmSignPetitionService } from 'src/app/logic/petition/confirm-sign-petition.service';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 
 @NgModule({
   declarations: [ConfirmSignPetitionComponent],
@@ -23,7 +25,8 @@ import { ConfirmSignPetitionService } from 'src/app/logic/petition/confirm-sign-
     MatIconModule,
     ConfirmSignPetitionRoutingModule,
     ReturnLinkModule,
-    MatProgressBarModule,
+    LoadingBarModule,
+    ErrorMsgModule,
   ],
   providers: [ConfirmSignPetitionService],
 })

--- a/src/app/features/sign-petition/sign-petition.component.html
+++ b/src/app/features/sign-petition/sign-petition.component.html
@@ -70,6 +70,14 @@
         <ng-container class="flex w-full" *ngSwitchCase="'verify'">
           <dp-verify-sign
             [dataSignature]="signatureData"
+            [id]="
+              resultData.dataCandidate?.PK || resultData.dataIssue?.PK || ''
+            "
+            [title]="
+              resultData.dataCandidate?.name ||
+              resultData.dataIssue?.title ||
+              ''
+            "
             (cancelEvent)="cancel($event)"
           ></dp-verify-sign>
         </ng-container>

--- a/src/app/features/sign-petition/sign-petition.component.ts
+++ b/src/app/features/sign-petition/sign-petition.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Observable, Subject, merge } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { VoterRecordMatch } from 'src/app/core/api/API';
 import { GetPublicPetitionService } from 'src/app/logic/petition/get-public-petition.service';
 

--- a/src/app/features/sign-petition/sign-petition.component.ts
+++ b/src/app/features/sign-petition/sign-petition.component.ts
@@ -1,12 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject, Observable, Subject, merge } from 'rxjs';
+import { VoterRecordMatch } from 'src/app/core/api/API';
 import { GetPublicPetitionService } from 'src/app/logic/petition/get-public-petition.service';
-import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
-import { FilterData } from 'src/app/shared/models/exports';
+
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
-import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
-import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-petition-type';
 
 @Component({
   selector: 'dp-sign-petition',
@@ -16,9 +14,10 @@ export class SignPetitionComponent implements OnInit {
   protected success$!: Observable<ResponsePetition | undefined>;
   protected error$!: Observable<string | undefined>;
   protected loading$!: Observable<boolean>;
+
   protected currentStep$: BehaviorSubject<'verify' | 'view' | 'sign'> =
     new BehaviorSubject<'verify' | 'view' | 'sign'>('view');
-  protected signatureData!: SignaturePetitionData;
+  protected signatureData!: VoterRecordMatch;
 
   constructor(
     private _committeeLogic: GetPublicPetitionService,
@@ -35,14 +34,14 @@ export class SignPetitionComponent implements OnInit {
     );
   }
 
-  protected submitPersonalData(data: SignaturePetitionData) {
+  protected submitPersonalData(data: VoterRecordMatch) {
     this.signatureData = data;
     this.currentStep$.next('verify');
   }
 
   protected cancel(value: 'verify' | 'view' | 'sign') {
     if (value === 'sign') {
-      this.signatureData.verify = { verifyType: '' };
+      this.signatureData.methods = [];
     }
 
     this.currentStep$.next(value);

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.html
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.html
@@ -102,6 +102,12 @@
       <p class="text-xs text-[#5C5C5C] italic">
         Please use the address where you are registered to vote.
       </p>
+      <dp-error-msg
+        *ngIf="!(loading$ | async) && (error$ | async) as error"
+        [error]="error"
+      >
+      </dp-error-msg>
+      <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
       <div class="flex flex-col justify-center w-full gap-[15px]">
         <button
           class="w-full"

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.component.ts
@@ -16,9 +16,7 @@ import {
 } from 'src/app/core/api/API';
 import { State, states } from 'src/app/core/states';
 import { VoterRecordMatchService } from 'src/app/logic/petition/voter-record-match.service';
-import { Result } from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
-import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
 
 @Component({
   selector: 'dp-sign-this-petition',

--- a/src/app/features/sign-petition/sign-this-petition/sign-this-petition.module.ts
+++ b/src/app/features/sign-petition/sign-this-petition/sign-this-petition.module.ts
@@ -8,6 +8,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 
 @NgModule({
   declarations: [SignThisPetitionComponent],
@@ -21,6 +23,8 @@ import { RouterModule } from '@angular/router';
     FormsModule,
     ReactiveFormsModule,
     RouterModule,
+    LoadingBarModule,
+    ErrorMsgModule,
   ],
   exports: [SignThisPetitionComponent],
 })

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.html
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.html
@@ -8,131 +8,134 @@
     [text]="'Back To Signing'"
     (click)="cancel('sign')"
   ></dp-return-link>
-  <div class="flex flex-col gap-2 md:px-6">
+  <div
+    class="flex flex-col gap-2 md:px-6"
+    *ngIf="dataSignature.methods.length > 0"
+  >
     <p class="font-bold text-lg leading-6">Verify Your Signature</p>
     <p>Choose how you want to verify your signature</p>
   </div>
-  <ng-container *ngIf="!(loading$ | async)">
-    <ng-container *ngIf="result$ | async as result">
-      <div *ngIf="result.error as error" class="flex flex-row items-center">
-        <mat-icon
-          class="w-[14px] h-[14px]"
-          [svgIcon]="'custom_icons:c_close'"
-        ></mat-icon>
-        <span class="ml-[9px] text-[#FF3030]">{{ error }}</span>
-      </div>
-    </ng-container>
-  </ng-container>
-  <mat-progress-bar
-    mode="indeterminate"
-    color="primary"
-    *ngIf="loading$ | async"
-  ></mat-progress-bar>
-  <mat-radio-group
-    class="flex flex-col w-full gap-4"
-    formControlName="verifyType"
-    color="primary"
+  <dp-error-msg
+    *ngIf="!(loading$ | async) && (error$ | async) as error"
+    [error]="error"
   >
-    <dp-basic-card class="flex flex-col w-full">
-      <mat-radio-button value="license"
-        ><p class="font-bold text-base leading-5">
-          Divers License / State ID
-        </p></mat-radio-button
+  </dp-error-msg>
+  <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
+  <ng-container *ngIf="dataSignature.methods.length > 0; else noMethod">
+    <mat-radio-group
+      class="flex flex-col w-full gap-4"
+      formControlName="verifyType"
+      color="primary"
+    >
+      <dp-basic-card
+        class="flex flex-col w-full"
+        *ngIf="showMethod('STATE_ID')"
       >
-      <form
-        *ngIf="formGroup.value.verifyType === 'license'"
-        [formGroup]="formGroupLicense"
-        class="flex md:flex-row flex-col w-full gap-[26px]"
-      >
-        <mat-form-field class="md:max-w-[385px] w-full">
-          <mat-label>License Number</mat-label>
-          <input type="text" matInput formControlName="licenseNumber" />
-          <mat-error
-            *ngIf="this.formGroupLicense.get('licenseNumber')?.errors?.['required']"
-          >
-            <div class="flex flex-row items-center">
-              <mat-icon
-                class="w-[14px] h-[14px]"
-                [svgIcon]="'custom_icons:c_close'"
-              ></mat-icon>
-              <span class="ml-[9px]">License Number is required</span>
-            </div>
-          </mat-error>
-        </mat-form-field>
-        <mat-form-field class="md:max-w-[170px] w-full">
-          <mat-label>Date Of Birth</mat-label>
-          <input
-            matInput
-            [matDatepicker]="picker"
-            formControlName="dateOfBirth"
-          />
-          <mat-datepicker-toggle
-            matPrefix
-            [for]="picker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #picker></mat-datepicker>
-          <mat-error
-            *ngIf="this.formGroupLicense.get('dateOfBirth')?.errors?.['required']"
-          >
-            <div class="flex flex-row items-center">
-              <mat-icon
-                class="w-[14px] h-[14px]"
-                [svgIcon]="'custom_icons:c_close'"
-              ></mat-icon>
-              <span class="ml-[9px]">Date Of Birth is required</span>
-            </div>
-          </mat-error>
-          <mat-error *ngIf="!this.formGroupLicense.get('dateOfBirth')?.valid">
-            <div class="flex flex-row items-center">
-              <mat-icon
-                class="w-[14px] h-[14px]"
-                [svgIcon]="'custom_icons:c_close'"
-              ></mat-icon>
-              <span class="ml-[9px]">Invalid format</span>
-            </div>
-          </mat-error>
-        </mat-form-field>
-      </form>
-    </dp-basic-card>
-    <dp-basic-card class="flex flex-col w-full">
-      <mat-radio-button value="Email"
-        ><p class="font-bold text-base leading-5">Email</p></mat-radio-button
-      >
-      <p>
-        A confirmation code will be sent to the email address on file with your
-        voter registration.
-      </p>
-    </dp-basic-card>
-    <dp-basic-card class="flex flex-col w-full">
-      <mat-radio-button value="Text"
-        ><p class="font-bold text-base leading-5">Text</p></mat-radio-button
-      >
-      <p>
-        A confirmation code will be sent to the mobile number registered on file
-        with your voter registration.
-      </p>
-    </dp-basic-card>
-    <dp-basic-card class="flex flex-col w-full">
-      <mat-radio-button value="Call"
-        ><p class="font-bold text-base leading-5">Call</p></mat-radio-button
-      >
-      <p>
-        You will receive a phone call to the number that is on file with your
-        voter registration.
-      </p>
-    </dp-basic-card>
-    <dp-basic-card class="flex flex-col w-full">
-      <mat-radio-button value="USMail"
-        ><p class="font-bold text-base leading-5">
-          U.S. Mail
-        </p></mat-radio-button
-      >
-      <p>
-        A confirmation code will be mailed to the address on file with your
-        voter registration.
-      </p>
-    </dp-basic-card>
-  </mat-radio-group>
+        <mat-radio-button value="license"
+          ><p class="font-bold text-base leading-5">
+            Divers License / State ID
+          </p></mat-radio-button
+        >
+        <form
+          *ngIf="formGroup.value.verifyType === 'license'"
+          [formGroup]="formGroupLicense"
+          class="flex md:flex-row flex-col w-full gap-[26px]"
+        >
+          <mat-form-field class="md:max-w-[385px] w-full">
+            <mat-label>License Number</mat-label>
+            <input type="text" matInput formControlName="licenseNumber" />
+            <mat-error
+              *ngIf="this.formGroupLicense.get('licenseNumber')?.errors?.['required']"
+            >
+              <div class="flex flex-row items-center">
+                <mat-icon
+                  class="w-[14px] h-[14px]"
+                  [svgIcon]="'custom_icons:c_close'"
+                ></mat-icon>
+                <span class="ml-[9px]">License Number is required</span>
+              </div>
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field class="md:max-w-[170px] w-full">
+            <mat-label>Date Of Birth</mat-label>
+            <input
+              matInput
+              [matDatepicker]="picker"
+              formControlName="dateOfBirth"
+            />
+            <mat-datepicker-toggle
+              matPrefix
+              [for]="picker"
+            ></mat-datepicker-toggle>
+            <mat-datepicker #picker></mat-datepicker>
+            <mat-error
+              *ngIf="this.formGroupLicense.get('dateOfBirth')?.errors?.['required']"
+            >
+              <div class="flex flex-row items-center">
+                <mat-icon
+                  class="w-[14px] h-[14px]"
+                  [svgIcon]="'custom_icons:c_close'"
+                ></mat-icon>
+                <span class="ml-[9px]">Date Of Birth is required</span>
+              </div>
+            </mat-error>
+            <mat-error *ngIf="!this.formGroupLicense.get('dateOfBirth')?.valid">
+              <div class="flex flex-row items-center">
+                <mat-icon
+                  class="w-[14px] h-[14px]"
+                  [svgIcon]="'custom_icons:c_close'"
+                ></mat-icon>
+                <span class="ml-[9px]">Invalid format</span>
+              </div>
+            </mat-error>
+          </mat-form-field>
+        </form>
+      </dp-basic-card>
+      <dp-basic-card class="flex flex-col w-full" *ngIf="showMethod('EMAIL')">
+        <mat-radio-button value="Email"
+          ><p class="font-bold text-base leading-5">Email</p></mat-radio-button
+        >
+        <p>
+          A confirmation code will be sent to the email address on file with
+          your voter registration.
+        </p>
+      </dp-basic-card>
+      <dp-basic-card class="flex flex-col w-full" *ngIf="showMethod('TEXT')">
+        <mat-radio-button value="Text"
+          ><p class="font-bold text-base leading-5">Text</p></mat-radio-button
+        >
+        <p>
+          A confirmation code will be sent to the mobile number registered on
+          file with your voter registration.
+        </p>
+      </dp-basic-card>
+      <dp-basic-card class="flex flex-col w-full" *ngIf="showMethod('CALL')">
+        <mat-radio-button value="Call"
+          ><p class="font-bold text-base leading-5">Call</p></mat-radio-button
+        >
+        <p>
+          You will receive a phone call to the number that is on file with your
+          voter registration.
+        </p>
+      </dp-basic-card>
+      <dp-basic-card class="flex flex-col w-full" *ngIf="showMethod('POSTAL')">
+        <mat-radio-button value="USMail"
+          ><p class="font-bold text-base leading-5">
+            U.S. Mail
+          </p></mat-radio-button
+        >
+        <p>
+          A confirmation code will be mailed to the address on file with your
+          voter registration.
+        </p>
+      </dp-basic-card>
+    </mat-radio-group>
+  </ng-container>
+  <ng-template #noMethod
+    ><h3 class="font-bold">
+      We have not found a valid method of verifying your identity
+    </h3></ng-template
+  >
   <div class="hidden md:flex md:flex-row md:w-full md:justify-end md:gap-4">
     <button
       class="hidden md:flex"

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { map, merge, Observable, Subject, tap } from 'rxjs';
+import { map, merge, Observable, Subject } from 'rxjs';
 import {
   SignatureVerificationInput,
   VerificationMethod,

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -1,24 +1,28 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { map, merge, Observable, Subscription, tap } from 'rxjs';
+import { map, merge, Observable, Subject, tap } from 'rxjs';
+import {
+  SignatureVerificationInput,
+  VerificationMethod,
+  VoterRecordMatch,
+} from 'src/app/core/api/API';
 import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
-import { Result } from 'src/app/shared/models/exports';
-import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
-
-import { SignaturePetitionType } from 'src/app/shared/models/petition/signature-petition-type';
 
 @Component({
   selector: 'dp-verify-sign',
   templateUrl: './verify-sign.component.html',
+  providers: [SignPetitionService],
 })
 export class VerifySignComponent implements OnInit {
-  @Input() dataSignature!: SignaturePetitionData;
+  @Input() dataSignature!: VoterRecordMatch;
+  @Input() title!: string;
+  @Input() id!: string;
   protected formGroup: FormGroup;
   protected formGroupLicense: FormGroup;
   protected isContinue$: Observable<boolean>;
-  protected result$!: Observable<Result<string>>;
-  protected error: string | undefined;
+  protected error$!: Observable<string | undefined>;
+  private localError$: Subject<string> = new Subject();
   protected loading$!: Observable<boolean>;
 
   @Output() cancelEvent: EventEmitter<'verify' | 'view' | 'sign'> =
@@ -49,43 +53,71 @@ export class VerifySignComponent implements OnInit {
           : false;
       })
     );
-
-    this.result$ = this._signPetitionLogic.result$.pipe(
-      tap((result) => {
-        if (!!result.result) {
-          this._router.navigate(['/petition/confirm-code']);
-        } else {
-          this.error = result.error;
-        }
-      })
-    );
-    this.loading$ = this._signPetitionLogic.loading$;
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this._signPetitionLogic.success$.subscribe((data) => {
+      if (data?.error) {
+        this.localError$.next(data.error);
+      } else if (data?.confirmationRequired) {
+        this._router.navigate(['/petition/confirm-code']);
+      } else {
+        this._router.navigate(['/petition/result-confirm-code']);
+      }
+    });
+    this.loading$ = this._signPetitionLogic.loading$;
+    this.error$ = merge(this._signPetitionLogic.error$, this.localError$);
+  }
   cancel(value: 'verify' | 'view' | 'sign') {
     this.cancelEvent.emit(value);
   }
 
   submit() {
+    let _signatureVerificationInput: SignatureVerificationInput = {
+      address: this.dataSignature.address,
+      city: this.dataSignature.city,
+      fullName: this.dataSignature.fullName,
+      method: VerificationMethod.CALL,
+      methodPayload: [],
+      state: this.dataSignature.state,
+      token: this.dataSignature.token ?? '',
+      zipCode: this.dataSignature.zipCode,
+      id: this.id,
+      title: this.title,
+    };
     if (this.formGroup.valid) {
       if (this.formGroup.value.verifyType === 'license') {
         if (this.formGroupLicense.valid) {
-          this.dataSignature.verify = {
-            verifyType: this.formGroup.value.verifyType,
-            licenseNumber: this.formGroupLicense.value.licenseNumber,
-            dateOfBirth: this.formGroupLicense.value.dateOfBirth,
-          };
+          _signatureVerificationInput.method = VerificationMethod.STATE_ID;
+          _signatureVerificationInput.methodPayload = [
+            this.formGroupLicense.value.licenseNumber,
+            this.formGroupLicense.value.dateOfBirth,
+          ];
         } else {
           this.formGroupLicense.markAllAsTouched();
         }
       } else {
-        this.dataSignature.verify = {
-          verifyType: this.formGroup.value.verifyType,
-        };
+        switch (this.formGroup.value.verifyType) {
+          case 'Email':
+            _signatureVerificationInput.method = VerificationMethod.EMAIL;
+            break;
+          case 'Text':
+            _signatureVerificationInput.method = VerificationMethod.TEXT;
+            break;
+          case 'Call':
+            _signatureVerificationInput.method = VerificationMethod.CALL;
+            break;
+          case 'USMail':
+            _signatureVerificationInput.method = VerificationMethod.POSTAL;
+            break;
+        }
       }
 
-      this._signPetitionLogic.signPetition(this.dataSignature);
+      this._signPetitionLogic.signPetition(_signatureVerificationInput);
     }
+  }
+
+  showMethod(value: string): boolean {
+    return this.dataSignature.methods.indexOf(value) >= 0;
   }
 }

--- a/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
@@ -13,6 +13,8 @@ import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module'
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { RouterModule } from '@angular/router';
 import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 
 @NgModule({
   declarations: [VerifySignComponent],
@@ -30,8 +32,9 @@ import { SignPetitionService } from 'src/app/logic/petition/sign-petition.servic
     ReturnLinkModule,
     MatProgressBarModule,
     RouterModule,
+    LoadingBarModule,
+    ErrorMsgModule,
   ],
   exports: [VerifySignComponent],
-  providers: [SignPetitionService],
 })
 export class VerifySignModule {}

--- a/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.module.ts
@@ -12,7 +12,6 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { RouterModule } from '@angular/router';
-import { SignPetitionService } from 'src/app/logic/petition/sign-petition.service';
 import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
 import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
 

--- a/src/app/logic/petition/confirm-sign-petition.service.ts
+++ b/src/app/logic/petition/confirm-sign-petition.service.ts
@@ -9,6 +9,7 @@ import {
   Subject,
   tap,
 } from 'rxjs';
+import { CodeSubmissionResult } from 'src/app/core/api/API';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { Result } from 'src/app/shared/models/exports';
 import { PetitionService } from './petition.service';
@@ -16,9 +17,9 @@ import { PetitionService } from './petition.service';
 @Injectable()
 export class ConfirmSignPetitionService {
   public error$: Observable<string | undefined>;
-  public success$: Observable<string | undefined>;
+  public success$: Observable<CodeSubmissionResult | undefined>;
   public loading$: Observable<boolean>;
-  public result$: Observable<Result<string>>;
+  public result$: Observable<Result<CodeSubmissionResult>>;
   private submit$: Subject<string> = new Subject();
 
   constructor(

--- a/src/app/logic/petition/petition.service.ts
+++ b/src/app/logic/petition/petition.service.ts
@@ -5,6 +5,7 @@ import {
   ApprovePetitionMutation,
   CandidatePetition,
   CandidatePetitionInput,
+  CodeSubmissionResult,
   EditCandidatePetitionInput,
   EditCandidatePetitionMutation,
   EditIssuePetitionInput,
@@ -12,15 +13,22 @@ import {
   GetPetitionQuery,
   GetPetitionsByOwnerQuery,
   GetPetitionsByTypeQuery,
+  GetVoterRecordMatchQuery,
   IssuePetition,
   IssuePetitionInput,
   PetitionsByOwnerInput,
   PetitionsByTypeInput,
   PetitionStatusQuery,
   PetitionType,
+  SignatureVerification,
+  SignatureVerificationInput,
   SubmitCandidatePetitionMutation,
   SubmitIssuePetitionMutation,
+  SubmitSignatureMutation,
+  SubmitVerificationCodeMutation,
   TargetPetitionInput,
+  VoterRecordMatch,
+  VoterRecordMatchInput,
 } from 'src/app/core/api/API';
 import { AccountService } from 'src/app/core/account-service/account.service';
 
@@ -28,8 +36,12 @@ import { FilterData, Result } from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
 import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
 
-import { rejectPetition } from 'src/graphql/mutations';
-import { getPetitionsByType } from 'src/graphql/queries';
+import {
+  rejectPetition,
+  submitSignature,
+  submitVerificationCode,
+} from 'src/graphql/mutations';
+import { getPetitionsByType, getVoterRecordMatch } from 'src/graphql/queries';
 import { __values } from 'tslib';
 import { BufferPetition } from 'src/app/shared/models/petition/buffer-petitions';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
@@ -86,12 +98,58 @@ export class PetitionService {
     );
   }
 
-  signPetition(data: SignaturePetitionData): Observable<Result<string>> {
-    return of({ result: 'SUCCESS' }).pipe(delay(3000));
+  signPetition(
+    data: SignatureVerificationInput
+  ): Observable<Result<SignatureVerification>> {
+    return from(
+      API.graphql({
+        query: submitSignature,
+        variables: { data },
+        authMode: 'AWS_IAM',
+      }) as Promise<GraphQLResult<SubmitSignatureMutation>>
+    ).pipe(
+      tap((value) => this._loggingService.log(value)),
+      map(({ data }) => ({ result: data?.submitSignature })),
+      catchError((error) => of({ error: error.errors?.[0]?.message }))
+    );
   }
 
-  confirmSignaturePetition(data: string): Observable<Result<string>> {
-    return of({ result: 'SUCCESS' }).pipe(delay(3000));
+  getVoterRecordMatch(
+    data: VoterRecordMatchInput
+  ): Observable<Result<VoterRecordMatch>> {
+    return from(
+      API.graphql({
+        query: getVoterRecordMatch,
+        variables: { query: data },
+        authMode: 'AWS_IAM',
+      }) as Promise<GraphQLResult<GetVoterRecordMatchQuery>>
+    ).pipe(
+      tap((value) => this._loggingService.log(value)),
+      map(({ data }) => ({ result: data?.getVoterRecordMatch })),
+      catchError((error) => {
+        console.log(error);
+        return of({ error: error.errors?.[0]?.message });
+      })
+    );
+  }
+
+  confirmSignaturePetition(
+    data: string
+  ): Observable<Result<CodeSubmissionResult>> {
+    return from(
+      API.graphql({
+        query: submitVerificationCode,
+        variables: { code: data },
+        authMode: 'AWS_IAM',
+      }) as Promise<GraphQLResult<SubmitVerificationCodeMutation>>
+    ).pipe(
+      tap((value) => this._loggingService.log(value)),
+      map(({ data }) => ({ result: data?.submitVerificationCode })),
+      catchError((error) => {
+        console.log(error);
+        return of({ error: error.errors?.[0]?.message });
+      })
+    );
   }
 
   editPetitionIssue(

--- a/src/app/logic/petition/petition.service.ts
+++ b/src/app/logic/petition/petition.service.ts
@@ -30,12 +30,8 @@ import {
   VoterRecordMatch,
   VoterRecordMatchInput,
 } from 'src/app/core/api/API';
-import { AccountService } from 'src/app/core/account-service/account.service';
-
-import { FilterData, Result } from 'src/app/shared/models/exports';
+import { Result } from 'src/app/shared/models/exports';
 import { ResponsePetition } from 'src/app/shared/models/petition/response-petition';
-import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
-
 import {
   rejectPetition,
   submitSignature,
@@ -50,7 +46,6 @@ import {
   getPetitionsByOwner,
   getPetitionsByType as getPetitionsByTypeAn,
 } from 'src/graphql/not-generated/queries';
-import { getPetition as getPetitionCommittee } from 'src/graphql/queries';
 import {
   approvePetition,
   editCandidatePetition,
@@ -61,10 +56,6 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class PetitionService {
-  private IssuePetition: 'IssuePetition' = 'IssuePetition';
-  private CandidatePetition: 'CandidatePetition' = 'CandidatePetition';
-  private AddressData: 'AddressData' = 'AddressData';
-  private SignatureSummary: 'SignatureSummary' = 'SignatureSummary';
   constructor(private _loggingService: LoggingService) {}
 
   newIssuePetition(

--- a/src/app/logic/petition/sign-petition.service.ts
+++ b/src/app/logic/petition/sign-petition.service.ts
@@ -15,7 +15,6 @@ import {
 } from 'src/app/core/api/API';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { Result } from 'src/app/shared/models/exports';
-import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
 import { PetitionService } from './petition.service';
 
 @Injectable()

--- a/src/app/logic/petition/sign-petition.service.ts
+++ b/src/app/logic/petition/sign-petition.service.ts
@@ -9,6 +9,10 @@ import {
   Subject,
   tap,
 } from 'rxjs';
+import {
+  SignatureVerification,
+  SignatureVerificationInput,
+} from 'src/app/core/api/API';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { Result } from 'src/app/shared/models/exports';
 import { SignaturePetitionData } from 'src/app/shared/models/petition/signature-petition-data';
@@ -17,10 +21,10 @@ import { PetitionService } from './petition.service';
 @Injectable()
 export class SignPetitionService {
   public error$: Observable<string | undefined>;
-  public success$: Observable<string | undefined>;
+  public success$: Observable<SignatureVerification | undefined>;
   public loading$: Observable<boolean>;
-  public result$: Observable<Result<string>>;
-  private submit$: Subject<SignaturePetitionData> = new Subject();
+  public result$: Observable<Result<SignatureVerification>>;
+  private submit$: Subject<SignatureVerificationInput> = new Subject();
 
   constructor(
     private _petitionService: PetitionService,
@@ -66,7 +70,7 @@ export class SignPetitionService {
   /** This method begins the signing process of a petition
   @param value: SignaturePetitionData type: It contains the user contact data and the firm verification method
   */
-  signPetition(value: SignaturePetitionData) {
+  signPetition(value: SignatureVerificationInput) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/petition/voter-record-match.service.spec.ts
+++ b/src/app/logic/petition/voter-record-match.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { VoterRecordMatchService } from './voter-record-match.service';
+
+describe('SignPetitionService', () => {
+  let service: VoterRecordMatchService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(VoterRecordMatchService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/logic/petition/voter-record-match.service.ts
+++ b/src/app/logic/petition/voter-record-match.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import {
+  exhaustMap,
+  map,
+  merge,
+  Observable,
+  partition,
+  shareReplay,
+  Subject,
+  tap,
+} from 'rxjs';
+import {
+  SignatureVerification,
+  SignatureVerificationInput,
+  VoterRecordMatch,
+  VoterRecordMatchInput,
+} from 'src/app/core/api/API';
+import { LoggingService } from 'src/app/core/logging/loggin.service';
+import { Result } from 'src/app/shared/models/exports';
+import { PetitionService } from './petition.service';
+
+@Injectable()
+export class VoterRecordMatchService {
+  public error$: Observable<string | undefined>;
+  public success$: Observable<VoterRecordMatch | undefined>;
+  public loading$: Observable<boolean>;
+  public result$: Observable<Result<VoterRecordMatch>>;
+  private submit$: Subject<VoterRecordMatchInput> = new Subject();
+
+  constructor(
+    private _petitionService: PetitionService,
+    private _loggingService: LoggingService
+  ) {
+    this.result$ = this.submit$.pipe(
+      exhaustMap((data) => this._petitionService.getVoterRecordMatch(data)),
+      shareReplay(1)
+    );
+    const [success$, error$] = partition(this.result$, (value) =>
+      value.result ? true : false
+    );
+
+    this.success$ = success$.pipe(
+      map((value) => value.result),
+      tap((value) => this._loggingService.log(value)),
+      shareReplay(1)
+    );
+
+    this.error$ = error$.pipe(
+      map((value) => value.error),
+      tap((value) => this._loggingService.log(value)),
+      shareReplay(1)
+    );
+
+    const end$ = merge(this.success$, this.error$);
+
+    this.loading$ = merge(
+      this.submit$.pipe(
+        map((v) => true),
+        tap(() => console.log('start'))
+      ),
+      end$.pipe(
+        map((v) => false),
+        tap(() => console.log('end'))
+      )
+    ).pipe(shareReplay(1));
+  }
+  ngOnDestroy(): void {
+    this.submit$.complete();
+  }
+
+  getVoterRecordMatch(value: VoterRecordMatchInput) {
+    this.submit$.next(value);
+  }
+}

--- a/src/app/logic/petition/voter-record-match.service.ts
+++ b/src/app/logic/petition/voter-record-match.service.ts
@@ -9,12 +9,7 @@ import {
   Subject,
   tap,
 } from 'rxjs';
-import {
-  SignatureVerification,
-  SignatureVerificationInput,
-  VoterRecordMatch,
-  VoterRecordMatchInput,
-} from 'src/app/core/api/API';
+import { VoterRecordMatch, VoterRecordMatchInput } from 'src/app/core/api/API';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { Result } from 'src/app/shared/models/exports';
 import { PetitionService } from './petition.service';


### PR DESCRIPTION
Problem: Integrate API endpoint with the UI to endorse now option
Description: Integrate the process of signing a petition with the backend, readjust the process of validating the identity of a signer
Solution:
Add the voter-record-match service:
It allows verifying that the data provided by the user coincides with that of a registered voter
Add signature and signature verification queries to a petition:
Adds request queries to the backend for validating a user, signing a request, and sending the confirmation code
Corrects the logic of the process of signing a petition, Fix the logic of the signature verification process:
Readjusts the components related to the process of signing a petition to adjust them to the types of data received from the backend