### PR TITLE
DP-237 on creating an issue petition the petition text box should expand based on the amount of text i put in up to a limit

### DIFF
--- a/src/app/features/city-staff-home/city-staff-home.component.ts
+++ b/src/app/features/city-staff-home/city-staff-home.component.ts
@@ -49,6 +49,14 @@ export class CityStaffHomeComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.filterByCategory.forEach((item) => {
+      item.value === 'ANY' ? (item.active = true) : (item.active = false);
+    });
+    this.filterByStatus.forEach((item) => {
+      (item.value as PetitionStatusQuery) === 'ANY'
+        ? (item.active = true)
+        : (item.active = false);
+    });
     this.currentUser = this._accountLogic.currentUser?.attributes.given_name;
     this.successPetition$ = this._cityStaffHomeLogic.success$;
     this.error$ = this._cityStaffHomeLogic.error$;

--- a/src/app/features/new-petition/new-petition-issue/new-petition-issue.component.html
+++ b/src/app/features/new-petition/new-petition-issue/new-petition-issue.component.html
@@ -30,7 +30,12 @@
         </mat-form-field>
         <mat-form-field>
           <mat-label>Petition Text</mat-label>
-          <textarea matInput formControlName="detail"></textarea>
+          <textarea
+            matInput
+            formControlName="detail"
+            class="min-h-[50px] max-h-[150px]"
+            (keyup)="autoGrowTextZone($event)"
+          ></textarea>
           <mat-error>
             <div class="flex flex-row items-center">
               <mat-icon

--- a/src/app/features/new-petition/new-petition-issue/new-petition-issue.component.ts
+++ b/src/app/features/new-petition/new-petition-issue/new-petition-issue.component.ts
@@ -66,4 +66,9 @@ export class NewPetitionIssueComponent implements OnInit, OnDestroy {
   cancel() {
     this.cancelEvent.emit('type');
   }
+
+  autoGrowTextZone(e: any) {
+    e.target.style.height = '0px';
+    e.target.style.height = e.target.scrollHeight + 25 + 'px';
+  }
 }

--- a/src/app/features/sign-petition/result-sign-petition/result-sign-petition.component.spec.ts
+++ b/src/app/features/sign-petition/result-sign-petition/result-sign-petition.component.spec.ts
@@ -42,9 +42,7 @@ describe('ResultSignPetitionComponent', () => {
     expect(component).toBeTruthy();
   });
 
-
   it('must show the title received as a parameter in the route', () => {
-
     activatedRoute.setParamMap({ title: 'Example title' });
     fixture.detectChanges();
     const elements = fixture.debugElement.nativeElement.querySelectorAll('p');

--- a/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
+++ b/src/app/features/sign-petition/verify-sign/verify-sign.component.ts
@@ -91,7 +91,9 @@ export class VerifySignComponent implements OnInit {
           _signatureVerificationInput.method = VerificationMethod.STATE_ID;
           _signatureVerificationInput.methodPayload = [
             this.formGroupLicense.value.licenseNumber,
-            this.formGroupLicense.value.dateOfBirth,
+            (this.formGroupLicense.value.dateOfBirth as Date)
+              .toISOString()
+              .split('T')[0],
           ];
         } else {
           this.formGroupLicense.markAllAsTouched();

--- a/src/app/features/view-signatures/view-signatures.component.ts
+++ b/src/app/features/view-signatures/view-signatures.component.ts
@@ -136,11 +136,9 @@ export class ViewSignaturesComponent implements OnInit, OnDestroy {
     );*/
   }
   deny() {
-    /*
     this._denyLogic.denySignature(
-      this.signaturesSelected.map((value) => value.id)
+      this.signaturesSelected.map((value) => value.signer)
     );
-    */
   }
 
   sort(


### PR DESCRIPTION
Problem: Fix some incorrect behaviors in the application forms

Description: The text box of the component to create a new request of type issue should increase in size with respect to the text entered up to a maximum size. It is necessary to correct the format of the date sent to validate a signer by means of the State ID to make it match the values ​​mocked in the backend. The admin home page filters should be reset when returning to that view.

Solution:

The text box of the form to create an issue type request is corrected, now the box has a minimum height of 50px and progressively increases its size up to 150px according to the amount of text entered.

The date format of the "date of birth" field of a signer is corrected to the type "YYYY-MM-DD" so that it matches the mocked data in the backend and thus allows user validation.

The values ​​of the filters are reset on the home page of a staff user to avoid undesirable behavior