### PR TITLE
DP-334 Design and implement unit tests of authentication services

### DIFF
--- a/src/app/auth/sign-up-confirm/sign-up-confirm.component.ts
+++ b/src/app/auth/sign-up-confirm/sign-up-confirm.component.ts
@@ -67,7 +67,7 @@ export class SignUpConfirmComponent implements OnInit, OnDestroy {
     }
   }
   resendCode() {
-    this._signUpResendCodeLogic.formGroupValue(this.email ?? '');
+    this._signUpResendCodeLogic.resendCode(this.email ?? '');
   }
 
   ngOnDestroy(): void {

--- a/src/app/auth/sign-up/sign-up.component.spec.ts
+++ b/src/app/auth/sign-up/sign-up.component.spec.ts
@@ -73,7 +73,7 @@ describe('SignUpComponent', () => {
   });
 
   it('should call the funcion "SignUpCredentials" in the service when submit function is called in the component and the form is valid', () => {
-    const functionSpy = spyOn(_signUpService, 'SignUpCredentials');
+    const functionSpy = spyOn(_signUpService, 'signUpCredentials');
 
     component.formGroup.setValue({
       firstName: 'textExample',

--- a/src/app/auth/sign-up/sign-up.component.ts
+++ b/src/app/auth/sign-up/sign-up.component.ts
@@ -65,7 +65,7 @@ export class SignUpComponent implements OnInit {
         email: this.formGroup.value.email,
         password: this.formGroup.value.password,
       };
-      this._signUpLogic.SignUpCredentials(_signUpCredentials);
+      this._signUpLogic.signUpCredentials(_signUpCredentials);
     }
   }
 }

--- a/src/app/logic/auth/change-email.service.spec.ts
+++ b/src/app/logic/auth/change-email.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,78 @@ import { ChangeEmailService } from './change-email.service';
 describe('ChangeEmailService', () => {
   let service: ChangeEmailService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['changeEmail']);
     TestBed.configureTestingModule({
       providers: [
         ChangeEmailService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(ChangeEmailService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when changeEmail emit a correct value', () => {
+    valueServiceSpy.changeEmail.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.setChangeEmailData({ email: '' });
+  });
+
+  it('"success$" should emit a <string> value when changeEmail emit a correct value', () => {
+    valueServiceSpy.changeEmail.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.setChangeEmailData({ email: '' });
+  });
+
+  it('"error$" should emit a "string" value when changeEmail emit a error value', () => {
+    valueServiceSpy.changeEmail.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.setChangeEmailData({ email: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when changeEmail emit any value', () => {
+    valueServiceSpy.changeEmail.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.setChangeEmailData({ email: '' });
   });
 });

--- a/src/app/logic/auth/change-password.service.spec.ts
+++ b/src/app/logic/auth/change-password.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,78 @@ import { ChangePasswordService } from './change-password.service';
 describe('ChangePasswordService', () => {
   let service: ChangePasswordService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['changePassword']);
     TestBed.configureTestingModule({
       providers: [
         ChangePasswordService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(ChangePasswordService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when changePassword emit a correct value', () => {
+    valueServiceSpy.changePassword.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.setPasswordData({ newPassword: '', oldPassword: '' });
+  });
+
+  it('"success$" should emit a <string> value when changePassword emit a correct value', () => {
+    valueServiceSpy.changePassword.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.setPasswordData({ newPassword: '', oldPassword: '' });
+  });
+
+  it('"error$" should emit a "string" value when changePassword emit a error value', () => {
+    valueServiceSpy.changePassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.setPasswordData({ newPassword: '', oldPassword: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when changePassword emit any value', () => {
+    valueServiceSpy.changePassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.setPasswordData({ newPassword: '', oldPassword: '' });
   });
 });

--- a/src/app/logic/auth/change-personal-details.service.spec.ts
+++ b/src/app/logic/auth/change-personal-details.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,112 @@ import { ChangePersonalDetailsService } from './change-personal-details.service'
 describe('ChangePersonalDetailsService', () => {
   let service: ChangePersonalDetailsService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', [
+      'changePersonalDetails',
+    ]);
     TestBed.configureTestingModule({
       providers: [
         ChangePersonalDetailsService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(ChangePersonalDetailsService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when changePersonalDetails emit a correct value', () => {
+    valueServiceSpy.changePersonalDetails.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.setPersonalDetailsToUpdate({
+      address: '',
+      aptNumber: '',
+      city: '',
+      firstName: '',
+      lastName: '',
+      state: '',
+      zipCode: '',
+    });
+  });
+
+  it('"success$" should emit a <string> value when changePersonalDetails emit a correct value', () => {
+    valueServiceSpy.changePersonalDetails.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.setPersonalDetailsToUpdate({
+      address: '',
+      aptNumber: '',
+      city: '',
+      firstName: '',
+      lastName: '',
+      state: '',
+      zipCode: '',
+    });
+  });
+
+  it('"error$" should emit "string" value when changePersonalDetails emit a error value', () => {
+    valueServiceSpy.changePersonalDetails.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.setPersonalDetailsToUpdate({
+      address: '',
+      aptNumber: '',
+      city: '',
+      firstName: '',
+      lastName: '',
+      state: '',
+      zipCode: '',
+    });
+  });
+
+  it('"loading$" should emit a "boolean" value when changePersonalDetails emit any value', () => {
+    valueServiceSpy.changePersonalDetails.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.setPersonalDetailsToUpdate({
+      address: '',
+      aptNumber: '',
+      city: '',
+      firstName: '',
+      lastName: '',
+      state: '',
+      zipCode: '',
+    });
   });
 });

--- a/src/app/logic/auth/check-token-fp.service.spec.ts
+++ b/src/app/logic/auth/check-token-fp.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,86 @@ import { CheckTokenFpService } from './check-token-fp.service';
 describe('CheckTokenFpService', () => {
   let service: CheckTokenFpService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['checkTokenFP']);
     TestBed.configureTestingModule({
       providers: [
         CheckTokenFpService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(CheckTokenFpService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when checkTokenFP emit a correct value', () => {
+    valueServiceSpy.checkTokenFP.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.sendToken({
+      code: '',
+    });
+  });
+
+  it('"success$" should emit a <string> value when checkTokenFP emit a correct value', () => {
+    valueServiceSpy.checkTokenFP.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.sendToken({
+      code: '',
+    });
+  });
+
+  it('"error$" should emit "string" value when checkTokenFP emit a error value', () => {
+    valueServiceSpy.checkTokenFP.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.sendToken({
+      code: '',
+    });
+  });
+
+  it('"loading$" should emit a "boolean" value when checkTokenFP emit any value', () => {
+    valueServiceSpy.checkTokenFP.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.sendToken({
+      code: '',
+    });
   });
 });

--- a/src/app/logic/auth/complete-admin-sign-up.service.spec.ts
+++ b/src/app/logic/auth/complete-admin-sign-up.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,126 @@ import { CompleteAdminSignUpService } from './complete-admin-sign-up.service';
 describe('CompleteNewPasswordService', () => {
   let service: CompleteAdminSignUpService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['completeNewPassword']);
     TestBed.configureTestingModule({
       providers: [
         CompleteAdminSignUpService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(CompleteAdminSignUpService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<CognitoUserFacade> value when completeNewPassword emit a correct value', () => {
+    valueServiceSpy.completeNewPassword.and.returnValue(
+      of({
+        result: {
+          attributes: {
+            sub: '',
+            address: '',
+            email_verified: false,
+            given_name: '',
+            'custom:access_group': 'city_staff_guest',
+            family_name: '',
+            email: '',
+          },
+          challengeName: 'NEW_PASSWORD_REQUIRED',
+          username: '',
+        },
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: {
+          attributes: {
+            sub: '',
+            address: '',
+            email_verified: false,
+            given_name: '',
+            'custom:access_group': 'city_staff_guest',
+            family_name: '',
+            email: '',
+          },
+          challengeName: 'NEW_PASSWORD_REQUIRED',
+          username: '',
+        },
+      });
+    });
+    service.completeSignUp({ firstName: '', lastName: '', password: '' });
+  });
+
+  it('"success$" should emit a <CognitoUserFacade> value when completeNewPassword emit a correct value', () => {
+    valueServiceSpy.completeNewPassword.and.returnValue(
+      of({
+        result: {
+          attributes: {
+            sub: '',
+            address: '',
+            email_verified: false,
+            given_name: '',
+            'custom:access_group': 'city_staff_guest',
+            family_name: '',
+            email: '',
+          },
+          challengeName: 'NEW_PASSWORD_REQUIRED',
+          username: '',
+        },
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual({
+        attributes: {
+          sub: '',
+          address: '',
+          email_verified: false,
+          given_name: '',
+          'custom:access_group': 'city_staff_guest',
+          family_name: '',
+          email: '',
+        },
+        challengeName: 'NEW_PASSWORD_REQUIRED',
+        username: '',
+      });
+    });
+    service.completeSignUp({ firstName: '', lastName: '', password: '' });
+  });
+
+  it('"error$" should emit "string" value when completeNewPassword emit a error value', () => {
+    valueServiceSpy.completeNewPassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.completeSignUp({ firstName: '', lastName: '', password: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when completeNewPassword emit any value', () => {
+    valueServiceSpy.completeNewPassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.completeSignUp({ firstName: '', lastName: '', password: '' });
   });
 });

--- a/src/app/logic/auth/confirm-change-email.service.spec.ts
+++ b/src/app/logic/auth/confirm-change-email.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,78 @@ import { ConfirmChangeEmailService } from './confirm-change-email.service';
 describe('ConfirmChangeEmailService', () => {
   let service: ConfirmChangeEmailService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['confirmEmailChange']);
     TestBed.configureTestingModule({
       providers: [
         ConfirmChangeEmailService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(ConfirmChangeEmailService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when confirmEmailChange emit a correct value', () => {
+    valueServiceSpy.confirmEmailChange.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.setConfirmationCode({ code: '' });
+  });
+
+  it('"success$" should emit a <string> value when confirmEmailChange emit a correct value', () => {
+    valueServiceSpy.confirmEmailChange.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.setConfirmationCode({ code: '' });
+  });
+
+  it('"error$" should emit "string" value when confirmEmailChange emit a error value', () => {
+    valueServiceSpy.confirmEmailChange.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.setConfirmationCode({ code: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when confirmEmailChange emit any value', () => {
+    valueServiceSpy.confirmEmailChange.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.setConfirmationCode({ code: '' });
   });
 });

--- a/src/app/logic/auth/forgot-password.service.spec.ts
+++ b/src/app/logic/auth/forgot-password.service.spec.ts
@@ -1,26 +1,94 @@
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
-import { MockedAccountService } from 'src/testing/mocked-account-service';
 import { MockedLoggingService } from 'src/testing/mocked-logging-service';
 
 import { ForgotPasswordService } from './forgot-password.service';
 
 describe('ForgotPasswordService', () => {
   let service: ForgotPasswordService;
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
+  let router: Router;
 
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['forgotPassword']);
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([])],
       providers: [
         ForgotPasswordService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(ForgotPasswordService);
+    router = TestBed.inject(Router);
+
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when forgotPassword emit a correct value', () => {
+    valueServiceSpy.forgotPassword.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.recoverPasswordData({ email: '' });
+  });
+
+  it('"success$" should emit a <string> value when forgotPassword emit a correct value', () => {
+    valueServiceSpy.forgotPassword.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    let functSpy = spyOn(router, 'navigate');
+
+    service.success$.subscribe((data) => {
+      expect(functSpy).toHaveBeenCalled();
+    });
+    service.recoverPasswordData({ email: 'example@test.com' });
+  });
+
+  it('"error$" should emit "string" value when forgotPassword emit a error value', () => {
+    valueServiceSpy.forgotPassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.recoverPasswordData({ email: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when forgotPassword emit any value', () => {
+    valueServiceSpy.forgotPassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.recoverPasswordData({ email: '' });
   });
 });

--- a/src/app/logic/auth/forgot-password.service.ts
+++ b/src/app/logic/auth/forgot-password.service.ts
@@ -72,7 +72,7 @@ export class ForgotPasswordService {
   @param value: Recovery email of the user proportionate
   */
   recoverPasswordData(value: RecoverPasswordData) {
-    this.submit$.next(value);
     this.email = value.email;
+    this.submit$.next(value);
   }
 }

--- a/src/app/logic/auth/set-new-password.service.spec.ts
+++ b/src/app/logic/auth/set-new-password.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,77 @@ import { SetNewPasswordService } from './set-new-password.service';
 describe('SetNewPasswordService', () => {
   let service: SetNewPasswordService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['setNewPassword']);
     TestBed.configureTestingModule({
       providers: [
         SetNewPasswordService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(SetNewPasswordService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+  it('"result$" should emit a Result<string> value when setNewPassword emit a correct value', () => {
+    valueServiceSpy.setNewPassword.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.newPasswordData({ code: '', newPassword: '', username: '' });
+  });
+
+  it('"success$" should emit a <string> value when setNewPassword emit a correct value', () => {
+    valueServiceSpy.setNewPassword.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.newPasswordData({ code: '', newPassword: '', username: '' });
+  });
+
+  it('"error$" should emit "string" value when setNewPassword emit a error value', () => {
+    valueServiceSpy.setNewPassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.newPasswordData({ code: '', newPassword: '', username: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when setNewPassword emit any value', () => {
+    valueServiceSpy.setNewPassword.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.newPasswordData({ code: '', newPassword: '', username: '' });
   });
 });

--- a/src/app/logic/auth/sign-in.service.spec.ts
+++ b/src/app/logic/auth/sign-in.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,125 @@ import { SignInService } from './sign-in.service';
 describe('SignInService', () => {
   let service: SignInService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['signIn']);
     TestBed.configureTestingModule({
       providers: [
         SignInService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(SignInService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+  it('"result$" should emit a Result<CognitoUserFacade> value when signIn emit a correct value', () => {
+    valueServiceSpy.signIn.and.returnValue(
+      of({
+        result: {
+          attributes: {
+            sub: '',
+            address: '',
+            email_verified: false,
+            given_name: '',
+            'custom:access_group': 'city_staff_guest',
+            family_name: '',
+            email: '',
+          },
+          challengeName: 'NEW_PASSWORD_REQUIRED',
+          username: '',
+        },
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: {
+          attributes: {
+            sub: '',
+            address: '',
+            email_verified: false,
+            given_name: '',
+            'custom:access_group': 'city_staff_guest',
+            family_name: '',
+            email: '',
+          },
+          challengeName: 'NEW_PASSWORD_REQUIRED',
+          username: '',
+        },
+      });
+    });
+    service.requestSignIn({ email: '', password: '' });
+  });
+
+  it('"success$" should emit a <CognitoUserFacade> value when signIn emit a correct value', () => {
+    valueServiceSpy.signIn.and.returnValue(
+      of({
+        result: {
+          attributes: {
+            sub: '',
+            address: '',
+            email_verified: false,
+            given_name: '',
+            'custom:access_group': 'city_staff_guest',
+            family_name: '',
+            email: '',
+          },
+          challengeName: 'NEW_PASSWORD_REQUIRED',
+          username: '',
+        },
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual({
+        attributes: {
+          sub: '',
+          address: '',
+          email_verified: false,
+          given_name: '',
+          'custom:access_group': 'city_staff_guest',
+          family_name: '',
+          email: '',
+        },
+        challengeName: 'NEW_PASSWORD_REQUIRED',
+        username: '',
+      });
+    });
+    service.requestSignIn({ email: '', password: '' });
+  });
+
+  it('"error$" should emit "string" value when signIn emit a error value', () => {
+    valueServiceSpy.signIn.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.requestSignIn({ email: '', password: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when signIn emit any value', () => {
+    valueServiceSpy.signIn.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.requestSignIn({ email: '', password: '' });
   });
 });

--- a/src/app/logic/auth/sign-out.service.spec.ts
+++ b/src/app/logic/auth/sign-out.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,78 @@ import { SignOutService } from './sign-out.service';
 describe('SignOutService', () => {
   let service: SignOutService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['signOut']);
     TestBed.configureTestingModule({
       providers: [
         SignOutService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(SignOutService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when signOut emit a correct value', () => {
+    valueServiceSpy.signOut.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.signOut();
+  });
+
+  it('"success$" should emit a <string> value when signOut emit a correct value', () => {
+    valueServiceSpy.signOut.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.signOut();
+  });
+
+  it('"error$" should emit "string" value when signOut emit a error value', () => {
+    valueServiceSpy.signOut.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.signOut();
+  });
+
+  it('"loading$" should emit a "boolean" value when signOut emit any value', () => {
+    valueServiceSpy.signOut.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.signOut();
   });
 });

--- a/src/app/logic/auth/sign-up-confirm.service.spec.ts
+++ b/src/app/logic/auth/sign-up-confirm.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,77 @@ import { SignUpConfirmService } from './sign-up-confirm.service';
 describe('SignUpConfirmService', () => {
   let service: SignUpConfirmService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['signUpConfirm']);
     TestBed.configureTestingModule({
       providers: [
         SignUpConfirmService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(SignUpConfirmService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+  it('"result$" should emit a Result<string> value when signUpConfirm emit a correct value', () => {
+    valueServiceSpy.signUpConfirm.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.signUpConfirmationCode({ code: '', username: '' });
+  });
+
+  it('"success$" should emit a <string> value when signUpConfirm emit a correct value', () => {
+    valueServiceSpy.signUpConfirm.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('success');
+    });
+    service.signUpConfirmationCode({ code: '', username: '' });
+  });
+
+  it('"error$" should emit "string" value when signUpConfirm emit a error value', () => {
+    valueServiceSpy.signUpConfirm.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.signUpConfirmationCode({ code: '', username: '' });
+  });
+
+  it('"loading$" should emit a "boolean" value when signUpConfirm emit any value', () => {
+    valueServiceSpy.signUpConfirm.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.signUpConfirmationCode({ code: '', username: '' });
   });
 });

--- a/src/app/logic/auth/sign-up-resend-code.service.spec.ts
+++ b/src/app/logic/auth/sign-up-resend-code.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -9,18 +10,78 @@ import { SignUpResendCodeService } from './sign-up-resend-code.service';
 describe('SignUpResendCodeService', () => {
   let service: SignUpResendCodeService;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['resendSignUp']);
     TestBed.configureTestingModule({
       providers: [
         SignUpResendCodeService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(SignUpResendCodeService);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<string> value when resendSignUp emit a correct value', () => {
+    valueServiceSpy.resendSignUp.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.resendCode('');
+  });
+
+  it('"success$" should emit a <string> value when resendSignUp emit a correct value', () => {
+    valueServiceSpy.resendSignUp.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.success$.subscribe((data) => {
+      expect(data).toEqual('A new code has been sent to your email');
+    });
+    service.resendCode('');
+  });
+
+  it('"error$" should emit "string" value when resendSignUp emit a error value', () => {
+    valueServiceSpy.resendSignUp.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.resendCode('');
+  });
+
+  it('"loading$" should emit a "boolean" value when resendSignUp emit any value', () => {
+    valueServiceSpy.resendSignUp.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.resendCode('');
   });
 });

--- a/src/app/logic/auth/sign-up-resend-code.service.ts
+++ b/src/app/logic/auth/sign-up-resend-code.service.ts
@@ -68,7 +68,7 @@ export class SignUpResendCodeService {
   /** This method begins the process of forwarding of the confirmation code for the validation of the registration of a committee user.The user receives a new code in the contact email provided
   @param value: Registration email supplied by the user
   */
-  formGroupValue(value: string) {
+  resendCode(value: string) {
     this.submit$.next(value);
   }
 }

--- a/src/app/logic/auth/sign-up.service.spec.ts
+++ b/src/app/logic/auth/sign-up.service.spec.ts
@@ -1,4 +1,7 @@
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { AccountService } from 'src/app/core/account-service/account.service';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { MockedAccountService } from 'src/testing/mocked-account-service';
@@ -8,19 +11,119 @@ import { SignUpService } from './sign-up.service';
 
 describe('SignUpService', () => {
   let service: SignUpService;
+  let router: Router;
 
+  let valueServiceSpy: jasmine.SpyObj<AccountService>;
   beforeEach(() => {
+    const spy = jasmine.createSpyObj('AccountService', ['signUp']);
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([])],
       providers: [
         SignUpService,
-        { provide: AccountService, useClass: MockedAccountService },
+        { provide: AccountService, useValue: spy },
         { provide: LoggingService, useClass: MockedLoggingService },
       ],
     });
     service = TestBed.inject(SignUpService);
+    router = TestBed.inject(Router);
+    valueServiceSpy = TestBed.inject(
+      AccountService
+    ) as jasmine.SpyObj<AccountService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('"result$" should emit a Result<UserConnection> value when getAllUser emit a correct value', () => {
+    valueServiceSpy.signUp.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+
+    service.result$.subscribe((data) => {
+      expect(data).toEqual({
+        result: 'success',
+      });
+    });
+    service.signUpCredentials({
+      address: '',
+      aptNumber: '',
+      email: '',
+      firstName: '',
+      lastName: '',
+      password: '',
+      state: '',
+      zipCode: '',
+    });
+  });
+
+  it('"success$" should emit a <signUp> value when signUp emit a correct value', () => {
+    valueServiceSpy.signUp.and.returnValue(
+      of({
+        result: 'success',
+      })
+    );
+    let functSpy = spyOn(router, 'navigate');
+
+    service.success$.subscribe((data) => {
+      expect(functSpy).toHaveBeenCalled();
+    });
+    service.signUpCredentials({
+      address: '',
+      aptNumber: '',
+      email: 'example@test.com',
+      firstName: '',
+      lastName: '',
+      password: '',
+      state: '',
+      zipCode: '',
+    });
+  });
+
+  it('"error$" should emit "string" value when signUp emit a error value', () => {
+    valueServiceSpy.signUp.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.error$.subscribe((data) => {
+      expect(data).toEqual('some error');
+    });
+    service.signUpCredentials({
+      address: '',
+      aptNumber: '',
+      email: '',
+      firstName: '',
+      lastName: '',
+      password: '',
+      state: '',
+      zipCode: '',
+    });
+  });
+
+  it('"loading$" should emit a "boolean" value when signUp emit any value', () => {
+    valueServiceSpy.signUp.and.returnValue(
+      of({
+        error: 'some error',
+      })
+    );
+
+    service.loading$.subscribe((data) => {
+      data ? expect(data).toEqual(true) : expect(data).toEqual(false);
+    });
+
+    service.signUpCredentials({
+      address: '',
+      aptNumber: '',
+      email: '',
+      firstName: '',
+      lastName: '',
+      password: '',
+      state: '',
+      zipCode: '',
+    });
   });
 });

--- a/src/app/logic/auth/sign-up.service.ts
+++ b/src/app/logic/auth/sign-up.service.ts
@@ -74,8 +74,8 @@ export class SignUpService implements OnDestroy {
   /** This method begins the registration process of a new committee user
   @param value: SignUpCredials type object, contains the necessary registration data to register a new committee user
   */
-  SignUpCredentials(value: SignUpCredentials) {
-    this.submit$.next(value);
+  signUpCredentials(value: SignUpCredentials) {
     this.email = value.email;
+    this.submit$.next(value);
   }
 }


### PR DESCRIPTION
Problem: Design and implement unit tests of admin services
Description: Add unit tests to evaluate the characteristics of: change-email, change-password, change-personal-details, check-token-fp, complete-admin-sign-up confirm-change-email, forgot-password, set-new-password, sign-in, sign-out, sign-up-confirm, sign-up-resend-code, sign-up and account services

Solution:
Add unit tests for: change-email, change-password, change-personal-details, check-token-fp, complete-admin-sign-up confirm-change-email, forgot-password, set-new-password, sign-in, sign-out, sign-up-confirm, sign-up-resend-code, account-service and sign-up services