### PR TITLE
DP-338 Bug bash fit and finish sprint 11

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -90,6 +90,13 @@ const routes: Routes = [
           import('./auth/sign-up/sign-up.module').then((m) => m.SignUpModule),
       },
       {
+        path: 'return-code-form',
+        loadChildren: () =>
+          import('./auth/return-code-form/return-code-form.module').then(
+            (m) => m.ReturnCodeFormModule
+          ),
+      },
+      {
         path: 'sign-up/:email',
         loadChildren: () =>
           import('./auth/sign-up-confirm/sign-up-confirm.module').then(

--- a/src/app/auth/forgot-password/forgot-password.component.ts
+++ b/src/app/auth/forgot-password/forgot-password.component.ts
@@ -15,8 +15,6 @@ import { ForgotPasswordService } from 'src/app/logic/auth/exports';
   providers: [ForgotPasswordService],
 })
 export class ForgotPasswordComponent implements OnInit, OnDestroy {
-  protected hide_password = true;
-
   protected error$!: Observable<string | undefined>;
   protected loading$!: Observable<boolean>;
   private _unsubscribeAll: Subject<void> = new Subject();

--- a/src/app/auth/return-code-form/return-code-form-routing.module.ts
+++ b/src/app/auth/return-code-form/return-code-form-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ReturnCodeFormComponent } from './return-code-form.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ReturnCodeFormComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ReturnCodeFormRoutingModule {}

--- a/src/app/auth/return-code-form/return-code-form.component.html
+++ b/src/app/auth/return-code-form/return-code-form.component.html
@@ -1,0 +1,62 @@
+<div class="w-full flex justify-center">
+  <div class="flex flex-col max-w-[436px] w-full gap-4">
+    <h1 class="px-6 py-2 font-extrabold">Petition Creators</h1>
+    <form [formGroup]="formGroup" (ngSubmit)="submit()">
+      <dp-basic-card class="w-full">
+        <div class="w-full flex justify-start">
+          <h4 class="font-bold text-lg leading-6">
+            Enter the email that is linked to your account
+          </h4>
+        </div>
+        <dp-error-msg
+          *ngIf="!(loading$ | async) && (error$ | async) as error"
+          [error]="error"
+        >
+        </dp-error-msg>
+        <dp-loading-bar *ngIf="loading$ | async"></dp-loading-bar>
+        <div class="grid grid-cols-1 gap-4">
+          <mat-form-field>
+            <mat-label>Email</mat-label>
+            <input type="text" matInput formControlName="email" />
+            <mat-error
+              *ngIf="this.formGroup.get('email')?.errors?.['required']"
+            >
+              <div class="flex flex-row items-center">
+                <mat-icon
+                  class="w-[14px] h-[14px]"
+                  [svgIcon]="'custom_icons:c_close'"
+                ></mat-icon>
+                <span class="ml-[9px]">Email is required</span>
+              </div>
+            </mat-error>
+            <mat-error *ngIf="this.formGroup.get('email')?.errors?.['email']">
+              <div class="flex flex-row items-center">
+                <mat-icon
+                  class="w-[14px] h-[14px]"
+                  [svgIcon]="'custom_icons:c_close'"
+                ></mat-icon>
+                <span class="ml-[9px]">Email is incorrect</span>
+              </div>
+            </mat-error>
+          </mat-form-field>
+
+          <button
+            [disabled]="loading$ | async"
+            mat-flat-button
+            type="submit"
+            class="h-10 w-full mt-2"
+            color="primary"
+          >
+            Continue
+          </button>
+        </div>
+      </dp-basic-card>
+    </form>
+    <div class="w-full flex justify-center">
+      <dp-return-link
+        [route]="'/auth/sign-up'"
+        [text]="'Back to Sign-Up'"
+      ></dp-return-link>
+    </div>
+  </div>
+</div>

--- a/src/app/auth/return-code-form/return-code-form.component.spec.ts
+++ b/src/app/auth/return-code-form/return-code-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReturnCodeFormComponent } from './return-code-form.component';
+
+describe('ReturnCodeFormComponent', () => {
+  let component: ReturnCodeFormComponent;
+  let fixture: ComponentFixture<ReturnCodeFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ReturnCodeFormComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ReturnCodeFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/auth/return-code-form/return-code-form.component.ts
+++ b/src/app/auth/return-code-form/return-code-form.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'dp-return-code-form',
+  templateUrl: './return-code-form.component.html',
+})
+export class ReturnCodeFormComponent {
+  protected error$!: Observable<string | undefined>;
+  protected loading$!: Observable<boolean>;
+  public formGroup: FormGroup;
+  constructor(
+    private _fb: FormBuilder,
+
+    private _router: Router
+  ) {
+    this.formGroup = this._fb.group({
+      email: ['', [Validators.required, Validators.email]],
+    });
+  }
+
+  submit() {
+    if (this.formGroup.valid) {
+      this._router.navigate(['auth/sign-up/' + this.formGroup.value.email]);
+    }
+  }
+}

--- a/src/app/auth/return-code-form/return-code-form.module.ts
+++ b/src/app/auth/return-code-form/return-code-form.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReturnCodeFormComponent } from './return-code-form.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { BasicCardModule } from 'src/app/shared/basic-card/basic-card.module';
+import { ErrorMsgModule } from 'src/app/shared/error-msg/error-msg.module';
+import { LoadingBarModule } from 'src/app/shared/loading/loading-bar.module';
+import { ReturnLinkModule } from 'src/app/shared/return-link/return-link.module';
+import { ReturnCodeFormRoutingModule } from './return-code-form-routing.module';
+
+@NgModule({
+  declarations: [ReturnCodeFormComponent],
+  imports: [
+    CommonModule,
+    BasicCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    MatInputModule,
+    FormsModule,
+    ReactiveFormsModule,
+    ReturnLinkModule,
+    LoadingBarModule,
+    ErrorMsgModule,
+    ReturnCodeFormRoutingModule,
+  ],
+})
+export class ReturnCodeFormModule {}

--- a/src/app/auth/sign-up-confirm/sign-up-confirm.component.html
+++ b/src/app/auth/sign-up-confirm/sign-up-confirm.component.html
@@ -25,6 +25,15 @@
                 the code to confirm your new account
               </p></ng-template
             >
+            <p class="text-xs cursor-pointer">
+              Your email is: <span class="font-bold">{{ email }}</span>
+              <a
+                class="text-accent-500"
+                [routerLink]="'/auth/return-code-form'"
+              >
+                change email?</a
+              >
+            </p>
           </ng-container>
 
           <mat-form-field>

--- a/src/app/auth/sign-up/sign-up.component.html
+++ b/src/app/auth/sign-up/sign-up.component.html
@@ -244,5 +244,21 @@
         >
       </div>
     </div>
+    <div class="w-full flex flex-col md:flex-row justify-center">
+      <div class="w-full md:w-auto flex justify-center">
+        <h4 class="font-extrabold text-base tracking-wide">
+          Already registered?
+        </h4>
+      </div>
+      <div class="w-full md:w-auto flex justify-center">
+        <a [routerLink]="'/auth/return-code-form'"
+          ><h4
+            class="font-extrabold text-base tracking-wide mx-3 text-primary-500"
+          >
+            Enter Code or Resend Code
+          </h4></a
+        >
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/core/account-service/account.service.ts
+++ b/src/app/core/account-service/account.service.ts
@@ -226,7 +226,6 @@ export class AccountService {
           return Auth.signIn(this.userInfo.email, this.userInfo.password)
             .then((data: any) => {
               this._pristineCognitoUser = data;
-              console.log('aqui');
               this.updateUser();
 
               return { result: 'SUCCESS' };

--- a/src/app/core/account-service/account.service.ts
+++ b/src/app/core/account-service/account.service.ts
@@ -229,13 +229,11 @@ export class AccountService {
     return from(
       Auth.confirmSignUp(data.username.replace(/[^a-zA-Z0-9]/g, ''), data.code)
         .then((_) => {
-
           if (this.userInfo) {
             return Auth.signIn(this.userInfo.email, this.userInfo.password)
               .then((data: any) => {
                 this._pristineCognitoUser = data;
                 this.updateUser();
-
 
                 return { result: 'SUCCESS' };
               })

--- a/src/app/features/view-signatures/sort-signatures/sort-signatures.component.ts
+++ b/src/app/features/view-signatures/sort-signatures/sort-signatures.component.ts
@@ -10,11 +10,11 @@ export class SortSignaturesComponent implements OnInit {
   @Input() filterName: string = '';
   @Input() elements: {
     name: string;
-    value: 'signer_name' | 'signer_date' | 'address' | 'email' | 'registered';
+    value: 'name' | 'createdAt' | 'address' | 'signer' | 'status';
     active: boolean;
   }[] = [];
   @Output() event: EventEmitter<
-    'signer_name' | 'signer_date' | 'address' | 'email' | 'registered'
+    'name' | 'createdAt' | 'address' | 'signer' | 'status'
   > = new EventEmitter();
   protected cursor: string = this.disabled ? 'cursor-auto' : 'cursor-pointer';
   protected activeStyle: string = `border-solid border border-primary-500  bg-primany-100 font-extrabold text-primary-500 ${this.cursor}`;
@@ -26,7 +26,7 @@ export class SortSignaturesComponent implements OnInit {
 
   protected sendFilter(value: {
     name: string;
-    value: 'signer_name' | 'signer_date' | 'address' | 'email' | 'registered';
+    value: 'name' | 'createdAt' | 'address' | 'signer' | 'status';
     active: boolean;
   }) {
     if (!this.disabled) {

--- a/src/app/features/view-signatures/view-signatures.component.ts
+++ b/src/app/features/view-signatures/view-signatures.component.ts
@@ -48,14 +48,14 @@ export class ViewSignaturesComponent implements OnInit, OnDestroy {
   };
   protected sortBy: {
     name: string;
-    value: 'signer_name' | 'signer_date' | 'address' | 'email' | 'registered';
+    value: 'name' | 'createdAt' | 'address' | 'signer' | 'status';
     active: boolean;
   }[] = [
-    { name: 'Signer Name', value: 'signer_name', active: false },
-    { name: 'Signer Date', value: 'signer_date', active: false },
+    { name: 'Signer Name', value: 'name', active: false },
+    { name: 'Signer Date', value: 'createdAt', active: false },
     { name: 'Address', value: 'address', active: false },
-    { name: 'Email', value: 'email', active: false },
-    { name: 'Status', value: 'registered', active: false },
+    { name: 'Signer', value: 'signer', active: false },
+    { name: 'Status', value: 'status', active: false },
   ];
   protected filterByStatus: FilterByStatus[] = FilterByStatusSignatures;
 
@@ -128,15 +128,12 @@ export class ViewSignaturesComponent implements OnInit, OnDestroy {
     this.signaturesSelected = data;
   }
 
-  sort(
-    value: 'signer_name' | 'signer_date' | 'address' | 'email' | 'registered'
-  ) {
-    /*
+  sort(value: 'name' | 'createdAt' | 'address' | 'signer' | 'status') {
     this.items = [
       ...this.items.sort((a, b) => {
         return a[value] > b[value] ? 1 : a[value] < b[value] ? -1 : 0;
       }),
-    ];*/
+    ];
   }
 
   filterStatus(value: SignatureStatusQuery | PetitionStatusQuery) {

--- a/src/app/logic/auth/sign-up-confirm.service.ts
+++ b/src/app/logic/auth/sign-up-confirm.service.ts
@@ -40,7 +40,11 @@ export class SignUpConfirmService {
       map((value) => value.result),
       tap((value) => {
         this._loggingService.log(value);
-        this._router.navigate(['/committee/new-petition']);
+        if (value == 'SUCCESS') {
+          this._router.navigate(['/committee/new-petition']);
+        } else if (value === 'GO_TO_LOGIN') {
+          this._router.navigate(['/auth/login']);
+        }
       }),
       shareReplay(1)
     );

--- a/src/app/logic/auth/sign-up-resend-code.service.ts
+++ b/src/app/logic/auth/sign-up-resend-code.service.ts
@@ -21,7 +21,7 @@ export class SignUpResendCodeService {
   public error$: Observable<string | undefined>;
   public success$: Observable<string | undefined>;
   public loading$: Observable<boolean>;
-  public result$: Observable<Result<string>>;
+  public result$: Observable<Result<boolean>>;
   private submit$: Subject<string> = new Subject();
 
   constructor(
@@ -37,7 +37,11 @@ export class SignUpResendCodeService {
     );
 
     this.success$ = success$.pipe(
-      map(() => 'A new code has been sent to your email'),
+      map((_) =>
+        _
+          ? 'A new code has been sent to your email'
+          : 'There was an error sending your new code, please try again'
+      ),
       tap((value) => this._loggingService.log(value)),
       shareReplay(1)
     );


### PR DESCRIPTION
Problem: A new user of the committee does not have how to return to the confirmation form of a new account. Adjust the user code resubmission request process to fit the backend. Adjust the function of ordering signatures.
Description: Create a way for a committee user to return to the confirmation code entry form for a new account.
The process of requesting a new code by the user is no longer requested directly from cognito, so it is necessary to readjust this function. The option to order signatures must be set to the properties of the Signatures object from the backend to work properly.

Description: 
Solution:

Added a new component to allow the committee user to enter the registration email and go to the account confirmation form.

The option to change the email that is trying to confirm is added to correct possible errors

Added the option to navigate to the option to return to the confirmation form in the sign-up view

Changes the operation of the "resend code" option
The operation of the process of requesting a new verification code of an account of a committee user is adjusted

Corrects the operation of the "order signatures" option
Adjusts the behavior of the component to order signatures to the properties of the object received by the backend