### PR TITLE
DP-227 Integrates the function of approving petition signatures with the backend

### DIFF
--- a/src/app/logic/signature/approve-signature.service.ts
+++ b/src/app/logic/signature/approve-signature.service.ts
@@ -9,6 +9,7 @@ import {
   Subject,
   tap,
 } from 'rxjs';
+import { Signature, TargetSignatureInput } from 'src/app/core/api/API';
 import { LoggingService } from 'src/app/core/logging/loggin.service';
 import { Result } from 'src/app/shared/models/exports';
 import { SignatureService } from './signature.service';
@@ -16,10 +17,10 @@ import { SignatureService } from './signature.service';
 @Injectable()
 export class ApproveSignatureService {
   public error$: Observable<string | undefined>;
-  public success$: Observable<string | undefined>;
+  public success$: Observable<Signature | undefined>;
   public loading$: Observable<boolean>;
-  public result$: Observable<Result<string>>;
-  private submit$: Subject<string[]> = new Subject();
+  public result$: Observable<Result<Signature>>;
+  private submit$: Subject<TargetSignatureInput> = new Subject();
 
   constructor(
     private _signatureService: SignatureService,
@@ -66,7 +67,7 @@ export class ApproveSignatureService {
   @param id: The requested request ID
   */
 
-  approveSignature(id: string[]) {
+  approveSignature(id: TargetSignatureInput) {
     this.submit$.next(id);
   }
 }

--- a/src/app/logic/signature/signature.service.ts
+++ b/src/app/logic/signature/signature.service.ts
@@ -3,12 +3,17 @@ import { GraphQLResult } from '@aws-amplify/api-graphql';
 import { API } from 'aws-amplify';
 import { catchError, delay, from, map, Observable, of } from 'rxjs';
 import {
+  ApproveSignatureMutation,
   GetSignaturesByPetitionQuery,
+  RejectSignatureMutation,
+  Signature,
   SignatureConnection,
   SignaturesByPetitionInput,
+  TargetSignatureInput,
 } from 'src/app/core/api/API';
 import { FilterData, Result } from 'src/app/shared/models/exports';
 import { SignaturesData } from 'src/app/shared/models/signatures/signatures-data';
+import { approveSignature, rejectSignature } from 'src/graphql/mutations';
 import { getSignaturesByPetition } from 'src/graphql/queries';
 
 @Injectable({
@@ -31,10 +36,17 @@ export class SignatureService {
       catchError((error) => of({ error: error?.errors[0]?.message }))
     );
   }
-  approveSignature(id: string[]): Observable<Result<string>> {
-    return of({
-      result: id.length.toString(),
-    }).pipe(delay(3000));
+  approveSignature(data: TargetSignatureInput): Observable<Result<Signature>> {
+    return from(
+      API.graphql({
+        query: approveSignature,
+        variables: { data: data },
+        authMode: 'AMAZON_COGNITO_USER_POOLS',
+      }) as Promise<GraphQLResult<ApproveSignatureMutation>>
+    ).pipe(
+      map(({ data }) => ({ result: data?.approveSignature as Signature })),
+      catchError((error) => of({ error: error?.errors[0]?.message }))
+    );
   }
   denySignature(id: string[]): Observable<Result<string>> {
     return of({


### PR DESCRIPTION
Poblem: Integrates the function of approving petition signatures with the backend

Description: Add the call function to the api for the approval of a petition

Solucion

The call to the API for the approval of a request is added and the rest of the components are adjusted to adapt them to the operation of the backend. The functionality of sending multiple signatures to the backend in one call is removed since there is no support for this function yet