### PR TITLE
[INTERNAL] Dockerize frontend app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.env
+.env.local
+.git
+.github
+.vscode
+*/node_modules
+docker
+docker-compose.yml
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ testem.log
 .DS_Store
 Thumbs.db
 src/environments/aws-exports.ts
+
+# Environment used for Docker
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # Digital-Petitions
+
+# Docker Instructions
+
+## Building
+
+To build the image, run the following:
+
+```sh
+alpine_version=3.18 node_version=18.17.1 ./docker/build_image.sh
+```
+
+Once built, the image is used in the `docker-compose.yml` file as the
+base image for the service(s). Make sure the image name is updated to
+match the options entered during build.
+
+## Environment
+
+The Docker Compose configuration requires `env` files.
+
+- `.env` to store default keys (and values) used to configure
+various services and libraries.
+- `.env.local` a git ignored file that provides a way to override values
+from `.env` for local development.
+
+Ensure the local file exists:
+
+```sh
+touch .env.local
+```
+
+## Installing
+
+To install the node dependencies, run the following:
+
+```sh
+docker-compose run --rm app
+```
+
+## Running
+
+To bring the `app` service up, run the following:
+
+```sh
+docker-compose up app
+```
+
+This will start the app with the `ng serve` command and maps port `4200`
+to your local machine.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ match the options entered during build.
 The Docker Compose configuration requires `env` files.
 
 - `.env` to store default keys (and values) used to configure
-various services and libraries.
+  various services and libraries.
 - `.env.local` a git ignored file that provides a way to override values
-from `.env` for local development.
+  from `.env` for local development.
 
 Ensure the local file exists:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+x-shared-config:
+  app_image_name: &app_image_name
+    image: maplight/node:18.17.1-alpine3.18
+
+  app_base: &app_base
+    <<: *app_image_name
+    env_file:
+      - .env
+      - .env.local
+    environment:
+      - HISTFILE=/app/log/.bash_history
+      - NODE_ENV=${NODE_ENV:-development}
+    ports:
+      - 4200:4200
+    stdin_open: true
+    tty: true
+    tmpfs:
+      - /tmp:exec,mode=755
+    user: "1069:1420"
+    volumes:
+      - .:/app:cached
+    working_dir: /app
+
+services:
+  app:
+    <<: *app_base
+    command: run start:docker
+    entrypoint: npm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,66 @@
+# Configuration for Node base image
+ARG ALPINE_VERSION
+ARG NODE_VERSION
+
+FROM node:"${NODE_VERSION}-alpine${ALPINE_VERSION}"
+
+# Metadata
+LABEL maintainer="MapLight"
+
+# User and Group for app isolation
+ARG APP_UID=1069
+ARG APP_USER=app
+ARG APP_GID=1420
+ARG APP_GROUP=app
+ARG APP_DIR=/app
+
+ENV SHELL /bin/bash
+
+ARG PACKAGES="\
+    autoconf \
+    automake \
+    bash \
+    binutils \
+    build-base \
+    coreutils  \
+    execline \
+    findutils \
+    git \
+    grep \
+    less \
+    libstdc++ \
+    libtool \
+    man-pages \
+    openssl \
+    util-linux \
+    "
+
+# Install packages
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache ${PACKAGES}
+
+# Configure Node and PATH
+ENV NODE_MODULES_DIR "${APP_DIR}/node_modules"
+ENV NODE_BIN_DIR "${NODE_MODULES_DIR}/.bin"
+ENV PATH "${NODE_BIN_DIR}:${PATH}"
+
+# Add custom app User and Group
+RUN addgroup -S -g "${APP_GID}" "${APP_GROUP}" && \
+    adduser -S -g "${APP_GROUP}" -u "${APP_UID}" "${APP_USER}"
+
+# Create directories for the app code
+RUN mkdir -p "${APP_DIR}" \
+    "${APP_DIR}/tmp" \
+    "${NODE_MODULES_DIR}" \
+    "${NODE_BIN_DIR}"
+RUN chown -R "${APP_USER}":"${APP_GROUP}" "${APP_DIR}" \
+    "${NODE_MODULES_DIR}" \
+    "${NODE_BIN_DIR}"
+
+USER "${APP_USER}"
+
+WORKDIR "${APP_DIR}"
+
+# Commands will be supplied via `docker-compose`
+CMD []

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+if [ -z ${alpine_version+x} ]; then
+  echo "alpine_version must be set"
+  exit 1
+fi
+
+if [ -z ${node_version+x} ]; then
+  echo "node_version must be set"
+  exit 1
+fi
+
+build_date=$(date +%Y-%m-%d);
+
+# Build for local use only
+docker build \
+  --no-cache \
+  --build-arg ALPINE_VERSION="${alpine_version}" \
+  --build-arg NODE_VERSION="${node_version}" \
+  --force-rm \
+  --label "name=maplight/node" \
+  -t "maplight/node:${node_version}-alpine${alpine_version}" \
+  docker
+
+# Build for multiple platforms, if we were pushing to Docker Hub
+# docker buildx build \
+#   --no-cache \
+#   --build-arg ALPINE_VERSION="${alpine_version}" \
+#   --build-arg NODE_VERSION="${node_version}" \
+#   --force-rm \
+#   --label "name=maplight/node" \
+#   --platform linux/amd64,linux/arm64/v8 \
+#   -t "maplight/node:${node_version}-alpine${alpine_version}" \
+#   -o local \
+#   docker
+
+# Add the `push` flag to push to Docker Hub
+  # --push \
+
+# Modify the tag to include the build date
+  # -t "maplight/node:${node_version}-alpine${alpine_version}-${build_date}" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@aws-sdk/util-base64": "^3.208.0",
         "aws-amplify": "^5.0.5",
         "ngx-mask": "^14.2.3",
-        "rxjs": "~7.5.6",
+        "rxjs": "~7.8.0",
         "tinycolor2": "^1.5.2",
         "tslib": "^2.3.0",
         "zone.js": "~0.12.0"
@@ -21739,8 +21739,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.7",
-      "license": "Apache-2.0",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start:docker": "ng serve --host 0.0.0.0",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
# Overview

Adds a basic Docker & Docker Compose set up to allow for easier development environment creation and maintenance. Uses a "local" Docker image build strategy for now (we may end up pushing these images to a registry at some point).

## Details (from the commits)

Adds an initial set up for Docker and Docker Compose. The assumption is that we will build a "local" image for use with Docker Compose, so a `docker` folder has been added with a script and `Dockerfile` needed to build the node image.
    
The README is updated with basic instructions to get up and running.

## Bonus 🎁 

* Looks like Snyk updated a library a while back and it didn't get changed in the `package-lock.json`