### PR TITLE
[FEATURE] Add hex input to color picker DP-416

### DIFF
--- a/src/app/features/city-staff-site-design/color-picker/color-picker.component.html
+++ b/src/app/features/city-staff-site-design/color-picker/color-picker.component.html
@@ -2,17 +2,19 @@
   <mat-expansion-panel
     hideToggle
     class="py-2 px-4 gap-[10px] rounded-lg border border-[#D7D7D7] bg-[#FFFFFF] shadow-none"
+    disabled="isDisabled"
   >
     <mat-expansion-panel-header class="p-0 justify-start">
       <div class="flex flex-row gap-[10px] items-center">
         <div
           [ngClass]="'rounded-[4px] border border-gray-300 w-10 h-10'"
           [ngStyle]="{ 'background-color': color || 'white' }"
+          (click)="onColorClick()"
         ></div>
         <input
           (input)="sendInputColor($event)"
           [(ngModel)]="color"
-          class="w-full"
+          class="text-black w-full"
           maxlength="7"
           name="color"
           type="text"

--- a/src/app/features/city-staff-site-design/color-picker/color-picker.component.html
+++ b/src/app/features/city-staff-site-design/color-picker/color-picker.component.html
@@ -9,9 +9,14 @@
           [ngClass]="'rounded-[4px] border border-gray-300 w-10 h-10'"
           [ngStyle]="{ 'background-color': color || 'white' }"
         ></div>
-        <p class="text-sm leading-4">
-          {{ color | uppercase }}
-        </p>
+        <input
+          (input)="sendInputColor($event)"
+          [(ngModel)]="color"
+          class="w-full"
+          maxlength="7"
+          name="color"
+          type="text"
+        />
       </div>
     </mat-expansion-panel-header>
     <div class="flex flex-row gap-2 rounded-md">

--- a/src/app/features/city-staff-site-design/color-picker/color-picker.component.ts
+++ b/src/app/features/city-staff-site-design/color-picker/color-picker.component.ts
@@ -24,9 +24,8 @@ export class ColorPickerComponent implements OnInit {
   @Output() eventColor: EventEmitter<string | null> = new EventEmitter();
 
   // Emit color from input
-  sendInputColor(event: Event | null) {
-    const target = event?.target as HTMLInputElement;
-    this.eventColor.emit(target.value);
+  sendInputColor(_event: Event | null) {
+    this.eventColor.emit(this.color);
   }
 
   // Emit color from palette

--- a/src/app/features/city-staff-site-design/color-picker/color-picker.component.ts
+++ b/src/app/features/city-staff-site-design/color-picker/color-picker.component.ts
@@ -22,6 +22,14 @@ export class ColorPickerComponent implements OnInit {
   protected hue!: string | null;
   @Input() color!: string | null | undefined;
   @Output() eventColor: EventEmitter<string | null> = new EventEmitter();
+
+  // Emit color from input
+  sendInputColor(event: Event | null) {
+    const target = event?.target as HTMLInputElement;
+    this.eventColor.emit(target.value);
+  }
+
+  // Emit color from palette
   sendColor(value: string | null) {
     this.color = value;
     this.eventColor.emit(value);

--- a/src/app/features/city-staff-site-design/color-picker/color-picker.component.ts
+++ b/src/app/features/city-staff-site-design/color-picker/color-picker.component.ts
@@ -9,6 +9,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
+import { MatExpansionPanel } from '@angular/material/expansion';
 import { __importDefault } from 'tslib';
 
 @Component({
@@ -22,6 +23,12 @@ export class ColorPickerComponent implements OnInit {
   protected hue!: string | null;
   @Input() color!: string | null | undefined;
   @Output() eventColor: EventEmitter<string | null> = new EventEmitter();
+  @ViewChild(MatExpansionPanel) panel?: MatExpansionPanel;
+
+  // Allow panel to be opened/closed
+  onColorClick() {
+    this.panel?.toggle();
+  }
 
   // Emit color from input
   sendInputColor(_event: Event | null) {

--- a/src/app/features/city-staff-site-design/color-picker/color-picker.module.ts
+++ b/src/app/features/city-staff-site-design/color-picker/color-picker.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { ColorPickerComponent } from './color-picker.component';
 import { ColorPaletteModule } from './color-palette/color-palette.module';
 import { ColorSliderModule } from './color-slider/color-slider.module';
@@ -11,6 +12,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
     CommonModule,
     ColorPaletteModule,
     ColorSliderModule,
+    FormsModule,
     MatExpansionModule,
   ],
   exports: [ColorPickerComponent],


### PR DESCRIPTION
# Overview

Adds the ability to input the color hex value in the color picker.

Note: this modifies the behavior of the expansion panel to only toggle when the color square is clicked. This avoids some annoying behavior when clicking into the input field.

<img width="264" alt="2023-09-17-14-09-yta5a" src="https://github.com/maplight/Digital-Petitions/assets/9002/12e84fb3-8cee-4665-9577-c08be4467abd">

Fixed! ~~Note: there's probably some refinement that could happen around the click event that expands the color picker canvas, but this seems to be okay to me, for now.~~

# Ticket

[DP-416](https://maplight.atlassian.net/browse/DP-416)

[DP-416]: https://maplight.atlassian.net/browse/DP-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ