### PR TITLE
DP-411: Update to display petition title after code submit

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -42,8 +42,9 @@ type CandidatePetition implements Petition @aws_cognito_user_pools @aws_iam {
 }
 
 type CodeSubmissionResult @aws_iam {
-  error: Boolean!
-  message: String!
+    id: ID
+    title: String
+    error: String
 }
 
 type IssuePetition implements Petition @aws_cognito_user_pools @aws_iam {

--- a/src/app/core/api/API.ts
+++ b/src/app/core/api/API.ts
@@ -3,1246 +3,1252 @@
 //  This file was automatically generated and should not be edited.
 
 export type ApprovePetitionInput = {
-  PK: string,
-  deadline: string,
-  expectedVersion: number,
-  requiredSignatures: number,
+  PK: string;
+  deadline: string;
+  expectedVersion: number;
+  requiredSignatures: number;
 };
 
 export type Petition = {
-  __typename: "Petition",
-  PK: string,
-  createdAt: string,
-  owner: string,
-  signatureSummary?: SignatureSummary | null,
-  signatures: SignatureConnection,
-  status: PetitionStatus,
-  type: PetitionType,
-  updatedAt: string,
-  version: number,
+  __typename: 'Petition';
+  PK: string;
+  createdAt: string;
+  owner: string;
+  signatureSummary?: SignatureSummary | null;
+  signatures: SignatureConnection;
+  status: PetitionStatus;
+  type: PetitionType;
+  updatedAt: string;
+  version: number;
 };
 
 export type CandidatePetition = {
-  __typename: "CandidatePetition",
-  PK: string,
-  address: AddressData,
-  createdAt: string,
-  name: string,
-  office: string,
-  owner: string,
-  party: string,
-  signatureSummary?: SignatureSummary | null,
-  signatures: SignatureConnection,
-  status: PetitionStatus,
-  type: PetitionType,
-  updatedAt: string,
-  version: number,
+  __typename: 'CandidatePetition';
+  PK: string;
+  address: AddressData;
+  createdAt: string;
+  name: string;
+  office: string;
+  owner: string;
+  party: string;
+  signatureSummary?: SignatureSummary | null;
+  signatures: SignatureConnection;
+  status: PetitionStatus;
+  type: PetitionType;
+  updatedAt: string;
+  version: number;
 };
 
 export type AddressData = {
-  __typename: "AddressData",
-  address: string,
-  city?: string | null,
-  number?: string | null,
-  state: string,
-  zipCode?: string | null,
+  __typename: 'AddressData';
+  address: string;
+  city?: string | null;
+  number?: string | null;
+  state: string;
+  zipCode?: string | null;
 };
 
 export type SignatureSummary = {
-  __typename: "SignatureSummary",
-  approved?: number | null,
-  deadline?: string | null,
-  rejected?: number | null,
-  required?: number | null,
-  submitted?: number | null,
-  verified?: number | null,
+  __typename: 'SignatureSummary';
+  approved?: number | null;
+  deadline?: string | null;
+  rejected?: number | null;
+  required?: number | null;
+  submitted?: number | null;
+  verified?: number | null;
 };
 
 export type SignatureConnection = {
-  __typename: "SignatureConnection",
-  items:  Array<Signature >,
-  token?: string | null,
+  __typename: 'SignatureConnection';
+  items: Array<Signature>;
+  token?: string | null;
 };
 
 export type Signature = {
-  __typename: "Signature",
-  PK: string,
-  address: string,
-  createdAt: string,
-  isVerified: boolean,
-  method: VerificationMethod,
-  name: string,
-  signer: string,
-  status: SignatureStatus,
-  updatedAt: string,
-  verifiedAt?: string | null,
+  __typename: 'Signature';
+  PK: string;
+  address: string;
+  createdAt: string;
+  isVerified: boolean;
+  method: VerificationMethod;
+  name: string;
+  signer: string;
+  status: SignatureStatus;
+  updatedAt: string;
+  verifiedAt?: string | null;
 };
 
 export enum VerificationMethod {
-  CALL = "CALL",
-  EMAIL = "EMAIL",
-  POSTAL = "POSTAL",
-  STATE_ID = "STATE_ID",
-  TEXT = "TEXT",
+  CALL = 'CALL',
+  EMAIL = 'EMAIL',
+  POSTAL = 'POSTAL',
+  STATE_ID = 'STATE_ID',
+  TEXT = 'TEXT',
 }
-
 
 export enum SignatureStatus {
-  APPROVED = "APPROVED",
-  REJECTED = "REJECTED",
-  SUBMITTED = "SUBMITTED",
-  VERIFIED = "VERIFIED",
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  SUBMITTED = 'SUBMITTED',
+  VERIFIED = 'VERIFIED',
 }
-
 
 export enum PetitionStatus {
-  ACTIVE = "ACTIVE",
-  CANCELED = "CANCELED",
-  NEW = "NEW",
-  NOT_QUALIFIED = "NOT_QUALIFIED",
-  QUALIFIED = "QUALIFIED",
-  REJECTED = "REJECTED",
-  WITHDRAWN = "WITHDRAWN",
+  ACTIVE = 'ACTIVE',
+  CANCELED = 'CANCELED',
+  NEW = 'NEW',
+  NOT_QUALIFIED = 'NOT_QUALIFIED',
+  QUALIFIED = 'QUALIFIED',
+  REJECTED = 'REJECTED',
+  WITHDRAWN = 'WITHDRAWN',
 }
-
 
 export enum PetitionType {
-  CANDIDATE = "CANDIDATE",
-  ISSUE = "ISSUE",
+  CANDIDATE = 'CANDIDATE',
+  ISSUE = 'ISSUE',
 }
 
-
 export type IssuePetition = {
-  __typename: "IssuePetition",
-  PK: string,
-  createdAt: string,
-  detail: string,
-  owner: string,
-  signatureSummary?: SignatureSummary | null,
-  signatures: SignatureConnection,
-  status: PetitionStatus,
-  title: string,
-  type: PetitionType,
-  updatedAt: string,
-  version: number,
+  __typename: 'IssuePetition';
+  PK: string;
+  createdAt: string;
+  detail: string;
+  owner: string;
+  signatureSummary?: SignatureSummary | null;
+  signatures: SignatureConnection;
+  status: PetitionStatus;
+  title: string;
+  type: PetitionType;
+  updatedAt: string;
+  version: number;
 };
 
 export type TargetSignatureInput = {
-  signatureId: string,
+  signatureId: string;
 };
 
 export type StaffUserInput = {
-  email: string,
-  permissions: StaffAccessLevel,
+  email: string;
+  permissions: StaffAccessLevel;
 };
 
 export enum StaffAccessLevel {
-  ADMIN = "ADMIN",
-  GUEST = "GUEST",
-  STAFF = "STAFF",
+  ADMIN = 'ADMIN',
+  GUEST = 'GUEST',
+  STAFF = 'STAFF',
 }
 
-
 export type User = {
-  __typename: "User",
-  email: string,
-  firstName?: string | null,
-  lastName?: string | null,
-  permissions: AccessLevel,
-  username: string,
+  __typename: 'User';
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  permissions: AccessLevel;
+  username: string;
 };
 
 export enum AccessLevel {
-  ADMIN = "ADMIN",
-  GUEST = "GUEST",
-  NONE = "NONE",
-  PETITIONER = "PETITIONER",
-  STAFF = "STAFF",
+  ADMIN = 'ADMIN',
+  GUEST = 'GUEST',
+  NONE = 'NONE',
+  PETITIONER = 'PETITIONER',
+  STAFF = 'STAFF',
 }
 
-
 export type EditCandidatePetitionInput = {
-  PK: string,
-  address?: AddressInput | null,
-  expectedVersion: number,
-  office?: string | null,
-  party?: string | null,
+  PK: string;
+  address?: AddressInput | null;
+  expectedVersion: number;
+  office?: string | null;
+  party?: string | null;
 };
 
 export type AddressInput = {
-  address: string,
-  city?: string | null,
-  number?: string | null,
-  state: string,
-  zipCode?: string | null,
+  address: string;
+  city?: string | null;
+  number?: string | null;
+  state: string;
+  zipCode?: string | null;
 };
 
 export type EditIssuePetitionInput = {
-  PK: string,
-  detail?: string | null,
-  expectedVersion: number,
-  title?: string | null,
+  PK: string;
+  detail?: string | null;
+  expectedVersion: number;
+  title?: string | null;
 };
 
 export type TargetPetitionInput = {
-  PK: string,
-  expectedVersion: number,
+  PK: string;
+  expectedVersion: number;
 };
 
 export type CandidatePetitionInput = {
-  address: AddressInput,
-  name: string,
-  office: string,
-  party: string,
+  address: AddressInput;
+  name: string;
+  office: string;
+  party: string;
 };
 
 export type IssuePetitionInput = {
-  detail: string,
-  title: string,
+  detail: string;
+  title: string;
 };
 
 export type SignatureVerificationInput = {
-  address: string,
-  city: string,
-  fullName: string,
-  id?: string | null,
-  method: VerificationMethod,
-  methodPayload: Array< string | null >,
-  state: string,
-  title?: string | null,
-  token: string,
-  zipCode: string,
+  address: string;
+  city: string;
+  fullName: string;
+  id?: string | null;
+  method: VerificationMethod;
+  methodPayload: Array<string | null>;
+  state: string;
+  title?: string | null;
+  token: string;
+  zipCode: string;
 };
 
 export type SignatureVerification = {
-  __typename: "SignatureVerification",
-  address: string,
-  city: string,
-  confirmationRequired: boolean,
-  error?: string | null,
-  fullName: string,
-  id?: string | null,
-  method: VerificationMethod,
-  methodPayload: Array< string | null >,
-  state: string,
-  title?: string | null,
-  token: string,
-  zipCode: string,
+  __typename: 'SignatureVerification';
+  address: string;
+  city: string;
+  confirmationRequired: boolean;
+  error?: string | null;
+  fullName: string;
+  id?: string | null;
+  method: VerificationMethod;
+  methodPayload: Array<string | null>;
+  state: string;
+  title?: string | null;
+  token: string;
+  zipCode: string;
 };
 
 export type CodeSubmissionResult = {
-  __typename: "CodeSubmissionResult",
-  id?: string | null,
-  title?: string | null,
-  error?: string | null,
+  __typename: 'CodeSubmissionResult';
+  id?: string | null;
+  title?: string | null;
+  error?: string | null;
 };
 
 export type SiteConfigurationInput = {
-  buttonColor?: string | null,
-  expectedVersion: number,
-  headerColor?: string | null,
-  highlightColor?: string | null,
-  logoImage?: string | null,
+  buttonColor?: string | null;
+  expectedVersion: number;
+  headerColor?: string | null;
+  highlightColor?: string | null;
+  logoImage?: string | null;
 };
 
 export type SiteConfiguration = {
-  __typename: "SiteConfiguration",
-  buttonColor?: string | null,
-  headerColor?: string | null,
-  highlightColor?: string | null,
-  logoImage?: string | null,
-  version: number,
+  __typename: 'SiteConfiguration';
+  buttonColor?: string | null;
+  headerColor?: string | null;
+  highlightColor?: string | null;
+  logoImage?: string | null;
+  version: number;
 };
 
 export type UpdateUserAccessInput = {
-  permissions: AccessLevel,
-  username: string,
+  permissions: AccessLevel;
+  username: string;
 };
 
 export type PetitionsByOwnerInput = {
-  cursor?: string | null,
-  limit?: number | null,
-  owner: string,
-  status?: PetitionStatusQuery | null,
+  cursor?: string | null;
+  limit?: number | null;
+  owner: string;
+  status?: PetitionStatusQuery | null;
 };
 
 export enum PetitionStatusQuery {
-  ACTIVE = "ACTIVE",
-  ANY = "ANY",
-  CANCELED = "CANCELED",
-  INACTIVE = "INACTIVE",
-  NEW = "NEW",
-  NOT_QUALIFIED = "NOT_QUALIFIED",
-  QUALIFIED = "QUALIFIED",
-  REJECTED = "REJECTED",
-  WITHDRAWN = "WITHDRAWN",
+  ACTIVE = 'ACTIVE',
+  ANY = 'ANY',
+  CANCELED = 'CANCELED',
+  INACTIVE = 'INACTIVE',
+  NEW = 'NEW',
+  NOT_QUALIFIED = 'NOT_QUALIFIED',
+  QUALIFIED = 'QUALIFIED',
+  REJECTED = 'REJECTED',
+  WITHDRAWN = 'WITHDRAWN',
 }
 
-
 export type PetitionConnection = {
-  __typename: "PetitionConnection",
-  items:  Array<Petition >,
-  token?: string | null,
+  __typename: 'PetitionConnection';
+  items: Array<Petition>;
+  token?: string | null;
 };
 
 export type PetitionsByTypeInput = {
-  cursor?: string | null,
-  limit?: number | null,
-  status?: PetitionStatusQuery | null,
-  type?: PetitionType | null,
+  cursor?: string | null;
+  limit?: number | null;
+  status?: PetitionStatusQuery | null;
+  type?: PetitionType | null;
 };
 
 export type GetResourceUploadURLInput = {
-  type: AssetType,
+  type: AssetType;
 };
 
 export enum AssetType {
-  LOGO = "LOGO",
+  LOGO = 'LOGO',
 }
 
-
 export type GetResourceVersionInput = {
-  type: AssetType,
+  type: AssetType;
 };
 
 export type SignaturesByPetitionInput = {
-  cursor?: string | null,
-  limit?: number | null,
-  petition: string,
-  status?: SignatureStatusQuery | null,
+  cursor?: string | null;
+  limit?: number | null;
+  petition: string;
+  status?: SignatureStatusQuery | null;
 };
 
 export enum SignatureStatusQuery {
-  ANY = "ANY",
-  APPROVED = "APPROVED",
-  APPROVED_AND_VERIFIED = "APPROVED_AND_VERIFIED",
-  APPROVED_VERIFICATION_PENDING = "APPROVED_VERIFICATION_PENDING",
-  REJECTED = "REJECTED",
-  REJECTED_AND_VERIFIED = "REJECTED_AND_VERIFIED",
-  REJECTED_VERIFICATION_PENDING = "REJECTED_VERIFICATION_PENDING",
-  SUBMITTED = "SUBMITTED",
-  VERIFICATION_PENDING = "VERIFICATION_PENDING",
-  VERIFIED = "VERIFIED",
+  ANY = 'ANY',
+  APPROVED = 'APPROVED',
+  APPROVED_AND_VERIFIED = 'APPROVED_AND_VERIFIED',
+  APPROVED_VERIFICATION_PENDING = 'APPROVED_VERIFICATION_PENDING',
+  REJECTED = 'REJECTED',
+  REJECTED_AND_VERIFIED = 'REJECTED_AND_VERIFIED',
+  REJECTED_VERIFICATION_PENDING = 'REJECTED_VERIFICATION_PENDING',
+  SUBMITTED = 'SUBMITTED',
+  VERIFICATION_PENDING = 'VERIFICATION_PENDING',
+  VERIFIED = 'VERIFIED',
 }
 
-
 export type ListResourcesInput = {
-  cursor?: string | null,
-  limit?: number | null,
-  type: AssetType,
+  cursor?: string | null;
+  limit?: number | null;
+  type: AssetType;
 };
 
 export type ResourceConnection = {
-  __typename: "ResourceConnection",
-  items: Array< string >,
-  token?: string | null,
+  __typename: 'ResourceConnection';
+  items: Array<string>;
+  token?: string | null;
 };
 
 export type SearchUsersInput = {
-  cursor?: string | null,
-  limit?: number | null,
-  searchEmail?: string | null,
-  searchGroup?: AccessLevelQuery | null,
-  searchName?: string | null,
+  cursor?: string | null;
+  limit?: number | null;
+  searchEmail?: string | null;
+  searchGroup?: AccessLevelQuery | null;
+  searchName?: string | null;
 };
 
 export enum AccessLevelQuery {
-  ADMIN = "ADMIN",
-  GUEST = "GUEST",
-  PETITIONER = "PETITIONER",
-  STAFF = "STAFF",
+  ADMIN = 'ADMIN',
+  GUEST = 'GUEST',
+  PETITIONER = 'PETITIONER',
+  STAFF = 'STAFF',
 }
 
-
 export type UserConnection = {
-  __typename: "UserConnection",
-  items:  Array<User >,
-  token?: string | null,
+  __typename: 'UserConnection';
+  items: Array<User>;
+  token?: string | null;
 };
 
 export type VoterRecordMatchInput = {
-  address: string,
-  city: string,
-  fullName: string,
-  state: string,
-  zipCode: string,
+  address: string;
+  city: string;
+  fullName: string;
+  state: string;
+  zipCode: string;
 };
 
 export type VoterRecordMatch = {
-  __typename: "VoterRecordMatch",
-  address: string,
-  city: string,
-  fullName: string,
-  methods: Array< string >,
-  state: string,
-  token?: string | null,
-  zipCode: string,
+  __typename: 'VoterRecordMatch';
+  address: string;
+  city: string;
+  fullName: string;
+  methods: Array<string>;
+  state: string;
+  token?: string | null;
+  zipCode: string;
 };
 
 export type ApprovePetitionMutationVariables = {
-  data: ApprovePetitionInput,
+  data: ApprovePetitionInput;
 };
 
 export type ApprovePetitionMutation = {
-  approvePetition: ( {
-      __typename: "CandidatePetition",
-      PK: string,
-      createdAt: string,
-      owner: string,
-      signatureSummary?:  {
-        __typename: string,
-        approved?: number | null,
-        deadline?: string | null,
-        rejected?: number | null,
-        required?: number | null,
-        submitted?: number | null,
-        verified?: number | null,
-      } | null,
-      signatures:  {
-        __typename: string,
-        items:  Array< {
-          __typename: string,
-          PK: string,
-          address: string,
-          createdAt: string,
-          isVerified: boolean,
-          method: VerificationMethod,
-          name: string,
-          signer: string,
-          status: SignatureStatus,
-          updatedAt: string,
-          verifiedAt?: string | null,
-        } >,
-        token?: string | null,
-      },
-      status: PetitionStatus,
-      type: PetitionType,
-      updatedAt: string,
-      version: number,
-      address:  {
-        __typename: string,
-        address: string,
-        city?: string | null,
-        number?: string | null,
-        state: string,
-        zipCode?: string | null,
-      },
-      name: string,
-      office: string,
-      party: string,
-    } | {
-      __typename: "IssuePetition",
-      PK: string,
-      createdAt: string,
-      owner: string,
-      signatureSummary?:  {
-        __typename: string,
-        approved?: number | null,
-        deadline?: string | null,
-        rejected?: number | null,
-        required?: number | null,
-        submitted?: number | null,
-        verified?: number | null,
-      } | null,
-      signatures:  {
-        __typename: string,
-        items:  Array< {
-          __typename: string,
-          PK: string,
-          address: string,
-          createdAt: string,
-          isVerified: boolean,
-          method: VerificationMethod,
-          name: string,
-          signer: string,
-          status: SignatureStatus,
-          updatedAt: string,
-          verifiedAt?: string | null,
-        } >,
-        token?: string | null,
-      },
-      status: PetitionStatus,
-      type: PetitionType,
-      updatedAt: string,
-      version: number,
-      detail: string,
-      title: string,
-    }
-  ) | null,
+  approvePetition:
+    | (
+        | {
+            __typename: 'CandidatePetition';
+            PK: string;
+            createdAt: string;
+            owner: string;
+            signatureSummary?: {
+              __typename: string;
+              approved?: number | null;
+              deadline?: string | null;
+              rejected?: number | null;
+              required?: number | null;
+              submitted?: number | null;
+              verified?: number | null;
+            } | null;
+            signatures: {
+              __typename: string;
+              items: Array<{
+                __typename: string;
+                PK: string;
+                address: string;
+                createdAt: string;
+                isVerified: boolean;
+                method: VerificationMethod;
+                name: string;
+                signer: string;
+                status: SignatureStatus;
+                updatedAt: string;
+                verifiedAt?: string | null;
+              }>;
+              token?: string | null;
+            };
+            status: PetitionStatus;
+            type: PetitionType;
+            updatedAt: string;
+            version: number;
+            address: {
+              __typename: string;
+              address: string;
+              city?: string | null;
+              number?: string | null;
+              state: string;
+              zipCode?: string | null;
+            };
+            name: string;
+            office: string;
+            party: string;
+          }
+        | {
+            __typename: 'IssuePetition';
+            PK: string;
+            createdAt: string;
+            owner: string;
+            signatureSummary?: {
+              __typename: string;
+              approved?: number | null;
+              deadline?: string | null;
+              rejected?: number | null;
+              required?: number | null;
+              submitted?: number | null;
+              verified?: number | null;
+            } | null;
+            signatures: {
+              __typename: string;
+              items: Array<{
+                __typename: string;
+                PK: string;
+                address: string;
+                createdAt: string;
+                isVerified: boolean;
+                method: VerificationMethod;
+                name: string;
+                signer: string;
+                status: SignatureStatus;
+                updatedAt: string;
+                verifiedAt?: string | null;
+              }>;
+              token?: string | null;
+            };
+            status: PetitionStatus;
+            type: PetitionType;
+            updatedAt: string;
+            version: number;
+            detail: string;
+            title: string;
+          }
+      )
+    | null;
 };
 
 export type ApproveSignatureMutationVariables = {
-  data: TargetSignatureInput,
+  data: TargetSignatureInput;
 };
 
 export type ApproveSignatureMutation = {
-  approveSignature?:  {
-    __typename: "Signature",
-    PK: string,
-    address: string,
-    createdAt: string,
-    isVerified: boolean,
-    method: VerificationMethod,
-    name: string,
-    signer: string,
-    status: SignatureStatus,
-    updatedAt: string,
-    verifiedAt?: string | null,
-  } | null,
+  approveSignature?: {
+    __typename: 'Signature';
+    PK: string;
+    address: string;
+    createdAt: string;
+    isVerified: boolean;
+    method: VerificationMethod;
+    name: string;
+    signer: string;
+    status: SignatureStatus;
+    updatedAt: string;
+    verifiedAt?: string | null;
+  } | null;
 };
 
 export type CreateStaffUserMutationVariables = {
-  data: StaffUserInput,
+  data: StaffUserInput;
 };
 
 export type CreateStaffUserMutation = {
-  createStaffUser:  {
-    __typename: "User",
-    email: string,
-    firstName?: string | null,
-    lastName?: string | null,
-    permissions: AccessLevel,
-    username: string,
-  },
+  createStaffUser: {
+    __typename: 'User';
+    email: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    permissions: AccessLevel;
+    username: string;
+  };
 };
 
 export type DeleteStaffUserMutationVariables = {
-  username: string,
+  username: string;
 };
 
 export type DeleteStaffUserMutation = {
-  deleteStaffUser: boolean,
+  deleteStaffUser: boolean;
 };
 
 export type EditCandidatePetitionMutationVariables = {
-  data: EditCandidatePetitionInput,
+  data: EditCandidatePetitionInput;
 };
 
 export type EditCandidatePetitionMutation = {
-  editCandidatePetition?:  {
-    __typename: "CandidatePetition",
-    PK: string,
-    address:  {
-      __typename: "AddressData",
-      address: string,
-      city?: string | null,
-      number?: string | null,
-      state: string,
-      zipCode?: string | null,
-    },
-    createdAt: string,
-    name: string,
-    office: string,
-    owner: string,
-    party: string,
-    signatureSummary?:  {
-      __typename: "SignatureSummary",
-      approved?: number | null,
-      deadline?: string | null,
-      rejected?: number | null,
-      required?: number | null,
-      submitted?: number | null,
-      verified?: number | null,
-    } | null,
-    signatures:  {
-      __typename: "SignatureConnection",
-      items:  Array< {
-        __typename: "Signature",
-        PK: string,
-        address: string,
-        createdAt: string,
-        isVerified: boolean,
-        method: VerificationMethod,
-        name: string,
-        signer: string,
-        status: SignatureStatus,
-        updatedAt: string,
-        verifiedAt?: string | null,
-      } >,
-      token?: string | null,
-    },
-    status: PetitionStatus,
-    type: PetitionType,
-    updatedAt: string,
-    version: number,
-  } | null,
+  editCandidatePetition?: {
+    __typename: 'CandidatePetition';
+    PK: string;
+    address: {
+      __typename: 'AddressData';
+      address: string;
+      city?: string | null;
+      number?: string | null;
+      state: string;
+      zipCode?: string | null;
+    };
+    createdAt: string;
+    name: string;
+    office: string;
+    owner: string;
+    party: string;
+    signatureSummary?: {
+      __typename: 'SignatureSummary';
+      approved?: number | null;
+      deadline?: string | null;
+      rejected?: number | null;
+      required?: number | null;
+      submitted?: number | null;
+      verified?: number | null;
+    } | null;
+    signatures: {
+      __typename: 'SignatureConnection';
+      items: Array<{
+        __typename: 'Signature';
+        PK: string;
+        address: string;
+        createdAt: string;
+        isVerified: boolean;
+        method: VerificationMethod;
+        name: string;
+        signer: string;
+        status: SignatureStatus;
+        updatedAt: string;
+        verifiedAt?: string | null;
+      }>;
+      token?: string | null;
+    };
+    status: PetitionStatus;
+    type: PetitionType;
+    updatedAt: string;
+    version: number;
+  } | null;
 };
 
 export type EditIssuePetitionMutationVariables = {
-  data: EditIssuePetitionInput,
+  data: EditIssuePetitionInput;
 };
 
 export type EditIssuePetitionMutation = {
-  editIssuePetition?:  {
-    __typename: "IssuePetition",
-    PK: string,
-    createdAt: string,
-    detail: string,
-    owner: string,
-    signatureSummary?:  {
-      __typename: "SignatureSummary",
-      approved?: number | null,
-      deadline?: string | null,
-      rejected?: number | null,
-      required?: number | null,
-      submitted?: number | null,
-      verified?: number | null,
-    } | null,
-    signatures:  {
-      __typename: "SignatureConnection",
-      items:  Array< {
-        __typename: "Signature",
-        PK: string,
-        address: string,
-        createdAt: string,
-        isVerified: boolean,
-        method: VerificationMethod,
-        name: string,
-        signer: string,
-        status: SignatureStatus,
-        updatedAt: string,
-        verifiedAt?: string | null,
-      } >,
-      token?: string | null,
-    },
-    status: PetitionStatus,
-    title: string,
-    type: PetitionType,
-    updatedAt: string,
-    version: number,
-  } | null,
+  editIssuePetition?: {
+    __typename: 'IssuePetition';
+    PK: string;
+    createdAt: string;
+    detail: string;
+    owner: string;
+    signatureSummary?: {
+      __typename: 'SignatureSummary';
+      approved?: number | null;
+      deadline?: string | null;
+      rejected?: number | null;
+      required?: number | null;
+      submitted?: number | null;
+      verified?: number | null;
+    } | null;
+    signatures: {
+      __typename: 'SignatureConnection';
+      items: Array<{
+        __typename: 'Signature';
+        PK: string;
+        address: string;
+        createdAt: string;
+        isVerified: boolean;
+        method: VerificationMethod;
+        name: string;
+        signer: string;
+        status: SignatureStatus;
+        updatedAt: string;
+        verifiedAt?: string | null;
+      }>;
+      token?: string | null;
+    };
+    status: PetitionStatus;
+    title: string;
+    type: PetitionType;
+    updatedAt: string;
+    version: number;
+  } | null;
 };
 
 export type RejectPetitionMutationVariables = {
-  data: TargetPetitionInput,
+  data: TargetPetitionInput;
 };
 
 export type RejectPetitionMutation = {
-  rejectPetition: ( {
-      __typename: "CandidatePetition",
-      PK: string,
-      createdAt: string,
-      owner: string,
-      signatureSummary?:  {
-        __typename: string,
-        approved?: number | null,
-        deadline?: string | null,
-        rejected?: number | null,
-        required?: number | null,
-        submitted?: number | null,
-        verified?: number | null,
-      } | null,
-      signatures:  {
-        __typename: string,
-        items:  Array< {
-          __typename: string,
-          PK: string,
-          address: string,
-          createdAt: string,
-          isVerified: boolean,
-          method: VerificationMethod,
-          name: string,
-          signer: string,
-          status: SignatureStatus,
-          updatedAt: string,
-          verifiedAt?: string | null,
-        } >,
-        token?: string | null,
-      },
-      status: PetitionStatus,
-      type: PetitionType,
-      updatedAt: string,
-      version: number,
-      address:  {
-        __typename: string,
-        address: string,
-        city?: string | null,
-        number?: string | null,
-        state: string,
-        zipCode?: string | null,
-      },
-      name: string,
-      office: string,
-      party: string,
-    } | {
-      __typename: "IssuePetition",
-      PK: string,
-      createdAt: string,
-      owner: string,
-      signatureSummary?:  {
-        __typename: string,
-        approved?: number | null,
-        deadline?: string | null,
-        rejected?: number | null,
-        required?: number | null,
-        submitted?: number | null,
-        verified?: number | null,
-      } | null,
-      signatures:  {
-        __typename: string,
-        items:  Array< {
-          __typename: string,
-          PK: string,
-          address: string,
-          createdAt: string,
-          isVerified: boolean,
-          method: VerificationMethod,
-          name: string,
-          signer: string,
-          status: SignatureStatus,
-          updatedAt: string,
-          verifiedAt?: string | null,
-        } >,
-        token?: string | null,
-      },
-      status: PetitionStatus,
-      type: PetitionType,
-      updatedAt: string,
-      version: number,
-      detail: string,
-      title: string,
-    }
-  ) | null,
+  rejectPetition:
+    | (
+        | {
+            __typename: 'CandidatePetition';
+            PK: string;
+            createdAt: string;
+            owner: string;
+            signatureSummary?: {
+              __typename: string;
+              approved?: number | null;
+              deadline?: string | null;
+              rejected?: number | null;
+              required?: number | null;
+              submitted?: number | null;
+              verified?: number | null;
+            } | null;
+            signatures: {
+              __typename: string;
+              items: Array<{
+                __typename: string;
+                PK: string;
+                address: string;
+                createdAt: string;
+                isVerified: boolean;
+                method: VerificationMethod;
+                name: string;
+                signer: string;
+                status: SignatureStatus;
+                updatedAt: string;
+                verifiedAt?: string | null;
+              }>;
+              token?: string | null;
+            };
+            status: PetitionStatus;
+            type: PetitionType;
+            updatedAt: string;
+            version: number;
+            address: {
+              __typename: string;
+              address: string;
+              city?: string | null;
+              number?: string | null;
+              state: string;
+              zipCode?: string | null;
+            };
+            name: string;
+            office: string;
+            party: string;
+          }
+        | {
+            __typename: 'IssuePetition';
+            PK: string;
+            createdAt: string;
+            owner: string;
+            signatureSummary?: {
+              __typename: string;
+              approved?: number | null;
+              deadline?: string | null;
+              rejected?: number | null;
+              required?: number | null;
+              submitted?: number | null;
+              verified?: number | null;
+            } | null;
+            signatures: {
+              __typename: string;
+              items: Array<{
+                __typename: string;
+                PK: string;
+                address: string;
+                createdAt: string;
+                isVerified: boolean;
+                method: VerificationMethod;
+                name: string;
+                signer: string;
+                status: SignatureStatus;
+                updatedAt: string;
+                verifiedAt?: string | null;
+              }>;
+              token?: string | null;
+            };
+            status: PetitionStatus;
+            type: PetitionType;
+            updatedAt: string;
+            version: number;
+            detail: string;
+            title: string;
+          }
+      )
+    | null;
 };
 
 export type RejectSignatureMutationVariables = {
-  data: TargetSignatureInput,
+  data: TargetSignatureInput;
 };
 
 export type RejectSignatureMutation = {
-  rejectSignature?:  {
-    __typename: "Signature",
-    PK: string,
-    address: string,
-    createdAt: string,
-    isVerified: boolean,
-    method: VerificationMethod,
-    name: string,
-    signer: string,
-    status: SignatureStatus,
-    updatedAt: string,
-    verifiedAt?: string | null,
-  } | null,
+  rejectSignature?: {
+    __typename: 'Signature';
+    PK: string;
+    address: string;
+    createdAt: string;
+    isVerified: boolean;
+    method: VerificationMethod;
+    name: string;
+    signer: string;
+    status: SignatureStatus;
+    updatedAt: string;
+    verifiedAt?: string | null;
+  } | null;
 };
 
 export type RequestUserVerificationCodeResendMutationVariables = {
-  email: string,
+  email: string;
 };
 
 export type RequestUserVerificationCodeResendMutation = {
-  requestUserVerificationCodeResend: boolean,
+  requestUserVerificationCodeResend: boolean;
 };
 
 export type SubmitCandidatePetitionMutationVariables = {
-  data: CandidatePetitionInput,
+  data: CandidatePetitionInput;
 };
 
 export type SubmitCandidatePetitionMutation = {
-  submitCandidatePetition:  {
-    __typename: "CandidatePetition",
-    PK: string,
-    address:  {
-      __typename: "AddressData",
-      address: string,
-      city?: string | null,
-      number?: string | null,
-      state: string,
-      zipCode?: string | null,
-    },
-    createdAt: string,
-    name: string,
-    office: string,
-    owner: string,
-    party: string,
-    signatureSummary?:  {
-      __typename: "SignatureSummary",
-      approved?: number | null,
-      deadline?: string | null,
-      rejected?: number | null,
-      required?: number | null,
-      submitted?: number | null,
-      verified?: number | null,
-    } | null,
-    signatures:  {
-      __typename: "SignatureConnection",
-      items:  Array< {
-        __typename: "Signature",
-        PK: string,
-        address: string,
-        createdAt: string,
-        isVerified: boolean,
-        method: VerificationMethod,
-        name: string,
-        signer: string,
-        status: SignatureStatus,
-        updatedAt: string,
-        verifiedAt?: string | null,
-      } >,
-      token?: string | null,
-    },
-    status: PetitionStatus,
-    type: PetitionType,
-    updatedAt: string,
-    version: number,
-  },
+  submitCandidatePetition: {
+    __typename: 'CandidatePetition';
+    PK: string;
+    address: {
+      __typename: 'AddressData';
+      address: string;
+      city?: string | null;
+      number?: string | null;
+      state: string;
+      zipCode?: string | null;
+    };
+    createdAt: string;
+    name: string;
+    office: string;
+    owner: string;
+    party: string;
+    signatureSummary?: {
+      __typename: 'SignatureSummary';
+      approved?: number | null;
+      deadline?: string | null;
+      rejected?: number | null;
+      required?: number | null;
+      submitted?: number | null;
+      verified?: number | null;
+    } | null;
+    signatures: {
+      __typename: 'SignatureConnection';
+      items: Array<{
+        __typename: 'Signature';
+        PK: string;
+        address: string;
+        createdAt: string;
+        isVerified: boolean;
+        method: VerificationMethod;
+        name: string;
+        signer: string;
+        status: SignatureStatus;
+        updatedAt: string;
+        verifiedAt?: string | null;
+      }>;
+      token?: string | null;
+    };
+    status: PetitionStatus;
+    type: PetitionType;
+    updatedAt: string;
+    version: number;
+  };
 };
 
 export type SubmitIssuePetitionMutationVariables = {
-  data: IssuePetitionInput,
+  data: IssuePetitionInput;
 };
 
 export type SubmitIssuePetitionMutation = {
-  submitIssuePetition:  {
-    __typename: "IssuePetition",
-    PK: string,
-    createdAt: string,
-    detail: string,
-    owner: string,
-    signatureSummary?:  {
-      __typename: "SignatureSummary",
-      approved?: number | null,
-      deadline?: string | null,
-      rejected?: number | null,
-      required?: number | null,
-      submitted?: number | null,
-      verified?: number | null,
-    } | null,
-    signatures:  {
-      __typename: "SignatureConnection",
-      items:  Array< {
-        __typename: "Signature",
-        PK: string,
-        address: string,
-        createdAt: string,
-        isVerified: boolean,
-        method: VerificationMethod,
-        name: string,
-        signer: string,
-        status: SignatureStatus,
-        updatedAt: string,
-        verifiedAt?: string | null,
-      } >,
-      token?: string | null,
-    },
-    status: PetitionStatus,
-    title: string,
-    type: PetitionType,
-    updatedAt: string,
-    version: number,
-  },
+  submitIssuePetition: {
+    __typename: 'IssuePetition';
+    PK: string;
+    createdAt: string;
+    detail: string;
+    owner: string;
+    signatureSummary?: {
+      __typename: 'SignatureSummary';
+      approved?: number | null;
+      deadline?: string | null;
+      rejected?: number | null;
+      required?: number | null;
+      submitted?: number | null;
+      verified?: number | null;
+    } | null;
+    signatures: {
+      __typename: 'SignatureConnection';
+      items: Array<{
+        __typename: 'Signature';
+        PK: string;
+        address: string;
+        createdAt: string;
+        isVerified: boolean;
+        method: VerificationMethod;
+        name: string;
+        signer: string;
+        status: SignatureStatus;
+        updatedAt: string;
+        verifiedAt?: string | null;
+      }>;
+      token?: string | null;
+    };
+    status: PetitionStatus;
+    title: string;
+    type: PetitionType;
+    updatedAt: string;
+    version: number;
+  };
 };
 
 export type SubmitSignatureMutationVariables = {
-  data: SignatureVerificationInput,
+  data: SignatureVerificationInput;
 };
 
 export type SubmitSignatureMutation = {
-  submitSignature:  {
-    __typename: "SignatureVerification",
-    address: string,
-    city: string,
-    confirmationRequired: boolean,
-    error?: string | null,
-    fullName: string,
-    id?: string | null,
-    method: VerificationMethod,
-    methodPayload: Array< string | null >,
-    state: string,
-    title?: string | null,
-    token: string,
-    zipCode: string,
-  },
+  submitSignature: {
+    __typename: 'SignatureVerification';
+    address: string;
+    city: string;
+    confirmationRequired: boolean;
+    error?: string | null;
+    fullName: string;
+    id?: string | null;
+    method: VerificationMethod;
+    methodPayload: Array<string | null>;
+    state: string;
+    title?: string | null;
+    token: string;
+    zipCode: string;
+  };
 };
 
 export type SubmitVerificationCodeMutationVariables = {
-  code: string,
+  code: string;
 };
 
 export type SubmitVerificationCodeMutation = {
-  submitVerificationCode:  {
-    __typename: "CodeSubmissionResult",
-    id?: string | null,
-    title?: string | null,
-    error?: string | null,
-  },
+  submitVerificationCode: {
+    __typename: 'CodeSubmissionResult';
+    id?: string | null;
+    title?: string | null;
+    error?: string | null;
+  };
 };
 
 export type UpdateSiteConfigurationMutationVariables = {
-  data: SiteConfigurationInput,
+  data: SiteConfigurationInput;
 };
 
 export type UpdateSiteConfigurationMutation = {
-  updateSiteConfiguration:  {
-    __typename: "SiteConfiguration",
-    buttonColor?: string | null,
-    headerColor?: string | null,
-    highlightColor?: string | null,
-    logoImage?: string | null,
-    version: number,
-  },
+  updateSiteConfiguration: {
+    __typename: 'SiteConfiguration';
+    buttonColor?: string | null;
+    headerColor?: string | null;
+    highlightColor?: string | null;
+    logoImage?: string | null;
+    version: number;
+  };
 };
 
 export type UpdateUserAccessMutationVariables = {
-  data: UpdateUserAccessInput,
+  data: UpdateUserAccessInput;
 };
 
 export type UpdateUserAccessMutation = {
-  updateUserAccess:  {
-    __typename: "User",
-    email: string,
-    firstName?: string | null,
-    lastName?: string | null,
-    permissions: AccessLevel,
-    username: string,
-  },
+  updateUserAccess: {
+    __typename: 'User';
+    email: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    permissions: AccessLevel;
+    username: string;
+  };
 };
 
 export type GetPetitionQueryVariables = {
-  PK: string,
+  PK: string;
 };
 
 export type GetPetitionQuery = {
-  getPetition: ( {
-      __typename: "CandidatePetition",
-      PK: string,
-      createdAt: string,
-      owner: string,
-      signatureSummary?:  {
-        __typename: string,
-        approved?: number | null,
-        deadline?: string | null,
-        rejected?: number | null,
-        required?: number | null,
-        submitted?: number | null,
-        verified?: number | null,
-      } | null,
-      signatures:  {
-        __typename: string,
-        items:  Array< {
-          __typename: string,
-          PK: string,
-          address: string,
-          createdAt: string,
-          isVerified: boolean,
-          method: VerificationMethod,
-          name: string,
-          signer: string,
-          status: SignatureStatus,
-          updatedAt: string,
-          verifiedAt?: string | null,
-        } >,
-        token?: string | null,
-      },
-      status: PetitionStatus,
-      type: PetitionType,
-      updatedAt: string,
-      version: number,
-      address:  {
-        __typename: string,
-        address: string,
-        city?: string | null,
-        number?: string | null,
-        state: string,
-        zipCode?: string | null,
-      },
-      name: string,
-      office: string,
-      party: string,
-    } | {
-      __typename: "IssuePetition",
-      PK: string,
-      createdAt: string,
-      owner: string,
-      signatureSummary?:  {
-        __typename: string,
-        approved?: number | null,
-        deadline?: string | null,
-        rejected?: number | null,
-        required?: number | null,
-        submitted?: number | null,
-        verified?: number | null,
-      } | null,
-      signatures:  {
-        __typename: string,
-        items:  Array< {
-          __typename: string,
-          PK: string,
-          address: string,
-          createdAt: string,
-          isVerified: boolean,
-          method: VerificationMethod,
-          name: string,
-          signer: string,
-          status: SignatureStatus,
-          updatedAt: string,
-          verifiedAt?: string | null,
-        } >,
-        token?: string | null,
-      },
-      status: PetitionStatus,
-      type: PetitionType,
-      updatedAt: string,
-      version: number,
-      detail: string,
-      title: string,
-    }
-  ) | null,
+  getPetition:
+    | (
+        | {
+            __typename: 'CandidatePetition';
+            PK: string;
+            createdAt: string;
+            owner: string;
+            signatureSummary?: {
+              __typename: string;
+              approved?: number | null;
+              deadline?: string | null;
+              rejected?: number | null;
+              required?: number | null;
+              submitted?: number | null;
+              verified?: number | null;
+            } | null;
+            signatures: {
+              __typename: string;
+              items: Array<{
+                __typename: string;
+                PK: string;
+                address: string;
+                createdAt: string;
+                isVerified: boolean;
+                method: VerificationMethod;
+                name: string;
+                signer: string;
+                status: SignatureStatus;
+                updatedAt: string;
+                verifiedAt?: string | null;
+              }>;
+              token?: string | null;
+            };
+            status: PetitionStatus;
+            type: PetitionType;
+            updatedAt: string;
+            version: number;
+            address: {
+              __typename: string;
+              address: string;
+              city?: string | null;
+              number?: string | null;
+              state: string;
+              zipCode?: string | null;
+            };
+            name: string;
+            office: string;
+            party: string;
+          }
+        | {
+            __typename: 'IssuePetition';
+            PK: string;
+            createdAt: string;
+            owner: string;
+            signatureSummary?: {
+              __typename: string;
+              approved?: number | null;
+              deadline?: string | null;
+              rejected?: number | null;
+              required?: number | null;
+              submitted?: number | null;
+              verified?: number | null;
+            } | null;
+            signatures: {
+              __typename: string;
+              items: Array<{
+                __typename: string;
+                PK: string;
+                address: string;
+                createdAt: string;
+                isVerified: boolean;
+                method: VerificationMethod;
+                name: string;
+                signer: string;
+                status: SignatureStatus;
+                updatedAt: string;
+                verifiedAt?: string | null;
+              }>;
+              token?: string | null;
+            };
+            status: PetitionStatus;
+            type: PetitionType;
+            updatedAt: string;
+            version: number;
+            detail: string;
+            title: string;
+          }
+      )
+    | null;
 };
 
 export type GetPetitionsByOwnerQueryVariables = {
-  query?: PetitionsByOwnerInput | null,
+  query?: PetitionsByOwnerInput | null;
 };
 
 export type GetPetitionsByOwnerQuery = {
-  getPetitionsByOwner:  {
-    __typename: "PetitionConnection",
-    items:  Array<( {
-        __typename: "CandidatePetition",
-        PK: string,
-        createdAt: string,
-        owner: string,
-        signatureSummary?:  {
-          __typename: string,
-          approved?: number | null,
-          deadline?: string | null,
-          rejected?: number | null,
-          required?: number | null,
-          submitted?: number | null,
-          verified?: number | null,
-        } | null,
-        signatures:  {
-          __typename: string,
-          token?: string | null,
-        },
-        status: PetitionStatus,
-        type: PetitionType,
-        updatedAt: string,
-        version: number,
-        address:  {
-          __typename: string,
-          address: string,
-          city?: string | null,
-          number?: string | null,
-          state: string,
-          zipCode?: string | null,
-        },
-        name: string,
-        office: string,
-        party: string,
-      } | {
-        __typename: "IssuePetition",
-        PK: string,
-        createdAt: string,
-        owner: string,
-        signatureSummary?:  {
-          __typename: string,
-          approved?: number | null,
-          deadline?: string | null,
-          rejected?: number | null,
-          required?: number | null,
-          submitted?: number | null,
-          verified?: number | null,
-        } | null,
-        signatures:  {
-          __typename: string,
-          token?: string | null,
-        },
-        status: PetitionStatus,
-        type: PetitionType,
-        updatedAt: string,
-        version: number,
-        detail: string,
-        title: string,
-      }
-    ) >,
-    token?: string | null,
-  },
+  getPetitionsByOwner: {
+    __typename: 'PetitionConnection';
+    items: Array<
+      | {
+          __typename: 'CandidatePetition';
+          PK: string;
+          createdAt: string;
+          owner: string;
+          signatureSummary?: {
+            __typename: string;
+            approved?: number | null;
+            deadline?: string | null;
+            rejected?: number | null;
+            required?: number | null;
+            submitted?: number | null;
+            verified?: number | null;
+          } | null;
+          signatures: {
+            __typename: string;
+            token?: string | null;
+          };
+          status: PetitionStatus;
+          type: PetitionType;
+          updatedAt: string;
+          version: number;
+          address: {
+            __typename: string;
+            address: string;
+            city?: string | null;
+            number?: string | null;
+            state: string;
+            zipCode?: string | null;
+          };
+          name: string;
+          office: string;
+          party: string;
+        }
+      | {
+          __typename: 'IssuePetition';
+          PK: string;
+          createdAt: string;
+          owner: string;
+          signatureSummary?: {
+            __typename: string;
+            approved?: number | null;
+            deadline?: string | null;
+            rejected?: number | null;
+            required?: number | null;
+            submitted?: number | null;
+            verified?: number | null;
+          } | null;
+          signatures: {
+            __typename: string;
+            token?: string | null;
+          };
+          status: PetitionStatus;
+          type: PetitionType;
+          updatedAt: string;
+          version: number;
+          detail: string;
+          title: string;
+        }
+    >;
+    token?: string | null;
+  };
 };
 
 export type GetPetitionsByTypeQueryVariables = {
-  query?: PetitionsByTypeInput | null,
+  query?: PetitionsByTypeInput | null;
 };
 
 export type GetPetitionsByTypeQuery = {
-  getPetitionsByType:  {
-    __typename: "PetitionConnection",
-    items:  Array<( {
-        __typename: "CandidatePetition",
-        PK: string,
-        createdAt: string,
-        owner: string,
-        signatureSummary?:  {
-          __typename: string,
-          approved?: number | null,
-          deadline?: string | null,
-          rejected?: number | null,
-          required?: number | null,
-          submitted?: number | null,
-          verified?: number | null,
-        } | null,
-        signatures:  {
-          __typename: string,
-          token?: string | null,
-        },
-        status: PetitionStatus,
-        type: PetitionType,
-        updatedAt: string,
-        version: number,
-        address:  {
-          __typename: string,
-          address: string,
-          city?: string | null,
-          number?: string | null,
-          state: string,
-          zipCode?: string | null,
-        },
-        name: string,
-        office: string,
-        party: string,
-      } | {
-        __typename: "IssuePetition",
-        PK: string,
-        createdAt: string,
-        owner: string,
-        signatureSummary?:  {
-          __typename: string,
-          approved?: number | null,
-          deadline?: string | null,
-          rejected?: number | null,
-          required?: number | null,
-          submitted?: number | null,
-          verified?: number | null,
-        } | null,
-        signatures:  {
-          __typename: string,
-          token?: string | null,
-        },
-        status: PetitionStatus,
-        type: PetitionType,
-        updatedAt: string,
-        version: number,
-        detail: string,
-        title: string,
-      }
-    ) >,
-    token?: string | null,
-  },
+  getPetitionsByType: {
+    __typename: 'PetitionConnection';
+    items: Array<
+      | {
+          __typename: 'CandidatePetition';
+          PK: string;
+          createdAt: string;
+          owner: string;
+          signatureSummary?: {
+            __typename: string;
+            approved?: number | null;
+            deadline?: string | null;
+            rejected?: number | null;
+            required?: number | null;
+            submitted?: number | null;
+            verified?: number | null;
+          } | null;
+          signatures: {
+            __typename: string;
+            token?: string | null;
+          };
+          status: PetitionStatus;
+          type: PetitionType;
+          updatedAt: string;
+          version: number;
+          address: {
+            __typename: string;
+            address: string;
+            city?: string | null;
+            number?: string | null;
+            state: string;
+            zipCode?: string | null;
+          };
+          name: string;
+          office: string;
+          party: string;
+        }
+      | {
+          __typename: 'IssuePetition';
+          PK: string;
+          createdAt: string;
+          owner: string;
+          signatureSummary?: {
+            __typename: string;
+            approved?: number | null;
+            deadline?: string | null;
+            rejected?: number | null;
+            required?: number | null;
+            submitted?: number | null;
+            verified?: number | null;
+          } | null;
+          signatures: {
+            __typename: string;
+            token?: string | null;
+          };
+          status: PetitionStatus;
+          type: PetitionType;
+          updatedAt: string;
+          version: number;
+          detail: string;
+          title: string;
+        }
+    >;
+    token?: string | null;
+  };
 };
 
 export type GetResourceUploadURLQueryVariables = {
-  query: GetResourceUploadURLInput,
+  query: GetResourceUploadURLInput;
 };
 
 export type GetResourceUploadURLQuery = {
-  getResourceUploadURL?: string | null,
+  getResourceUploadURL?: string | null;
 };
 
 export type GetResourceVersionQueryVariables = {
-  query: GetResourceVersionInput,
+  query: GetResourceVersionInput;
 };
 
 export type GetResourceVersionQuery = {
-  getResourceVersion?: string | null,
+  getResourceVersion?: string | null;
 };
 
 export type GetSignaturesByPetitionQueryVariables = {
-  query?: SignaturesByPetitionInput | null,
+  query?: SignaturesByPetitionInput | null;
 };
 
 export type GetSignaturesByPetitionQuery = {
-  getSignaturesByPetition:  {
-    __typename: "SignatureConnection",
-    items:  Array< {
-      __typename: "Signature",
-      PK: string,
-      address: string,
-      createdAt: string,
-      isVerified: boolean,
-      method: VerificationMethod,
-      name: string,
-      signer: string,
-      status: SignatureStatus,
-      updatedAt: string,
-      verifiedAt?: string | null,
-    } >,
-    token?: string | null,
-  },
+  getSignaturesByPetition: {
+    __typename: 'SignatureConnection';
+    items: Array<{
+      __typename: 'Signature';
+      PK: string;
+      address: string;
+      createdAt: string;
+      isVerified: boolean;
+      method: VerificationMethod;
+      name: string;
+      signer: string;
+      status: SignatureStatus;
+      updatedAt: string;
+      verifiedAt?: string | null;
+    }>;
+    token?: string | null;
+  };
 };
 
 export type GetSiteResourcesQueryVariables = {
-  query: ListResourcesInput,
+  query: ListResourcesInput;
 };
 
 export type GetSiteResourcesQuery = {
-  getSiteResources:  {
-    __typename: "ResourceConnection",
-    items: Array< string >,
-    token?: string | null,
-  },
+  getSiteResources: {
+    __typename: 'ResourceConnection';
+    items: Array<string>;
+    token?: string | null;
+  };
 };
 
 export type GetUsersQueryVariables = {
-  query?: SearchUsersInput | null,
+  query?: SearchUsersInput | null;
 };
 
 export type GetUsersQuery = {
-  getUsers:  {
-    __typename: "UserConnection",
-    items:  Array< {
-      __typename: "User",
-      email: string,
-      firstName?: string | null,
-      lastName?: string | null,
-      permissions: AccessLevel,
-      username: string,
-    } >,
-    token?: string | null,
-  },
+  getUsers: {
+    __typename: 'UserConnection';
+    items: Array<{
+      __typename: 'User';
+      email: string;
+      firstName?: string | null;
+      lastName?: string | null;
+      permissions: AccessLevel;
+      username: string;
+    }>;
+    token?: string | null;
+  };
 };
 
 export type GetVoterRecordMatchQueryVariables = {
-  query: VoterRecordMatchInput,
+  query: VoterRecordMatchInput;
 };
 
 export type GetVoterRecordMatchQuery = {
-  getVoterRecordMatch:  {
-    __typename: "VoterRecordMatch",
-    address: string,
-    city: string,
-    fullName: string,
-    methods: Array< string >,
-    state: string,
-    token?: string | null,
-    zipCode: string,
-  },
+  getVoterRecordMatch: {
+    __typename: 'VoterRecordMatch';
+    address: string;
+    city: string;
+    fullName: string;
+    methods: Array<string>;
+    state: string;
+    token?: string | null;
+    zipCode: string;
+  };
 };
 
 export type PublicEchoQueryVariables = {
-  ping: string,
+  ping: string;
 };
 
 export type PublicEchoQuery = {
-  publicEcho: string,
+  publicEcho: string;
 };
 
 export type SiteConfigurationQuery = {
-  siteConfiguration:  {
-    __typename: "SiteConfiguration",
-    buttonColor?: string | null,
-    headerColor?: string | null,
-    highlightColor?: string | null,
-    logoImage?: string | null,
-    version: number,
-  },
+  siteConfiguration: {
+    __typename: 'SiteConfiguration';
+    buttonColor?: string | null;
+    headerColor?: string | null;
+    highlightColor?: string | null;
+    logoImage?: string | null;
+    version: number;
+  };
 };
 
 export type UpdatedSiteConfigurationSubscription = {
-  updatedSiteConfiguration?:  {
-    __typename: "SiteConfiguration",
-    buttonColor?: string | null,
-    headerColor?: string | null,
-    highlightColor?: string | null,
-    logoImage?: string | null,
-    version: number,
-  } | null,
+  updatedSiteConfiguration?: {
+    __typename: 'SiteConfiguration';
+    buttonColor?: string | null;
+    headerColor?: string | null;
+    highlightColor?: string | null;
+    logoImage?: string | null;
+    version: number;
+  } | null;
 };

--- a/src/app/core/api/API.ts
+++ b/src/app/core/api/API.ts
@@ -232,8 +232,9 @@ export type SignatureVerification = {
 
 export type CodeSubmissionResult = {
   __typename: "CodeSubmissionResult",
-  error: boolean,
-  message: string,
+  id?: string | null,
+  title?: string | null,
+  error?: string | null,
 };
 
 export type SiteConfigurationInput = {
@@ -860,8 +861,9 @@ export type SubmitVerificationCodeMutationVariables = {
 export type SubmitVerificationCodeMutation = {
   submitVerificationCode:  {
     __typename: "CodeSubmissionResult",
-    error: boolean,
-    message: string,
+    id?: string | null,
+    title?: string | null,
+    error?: string | null,
   },
 };
 

--- a/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.spec.ts
+++ b/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.spec.ts
@@ -170,8 +170,9 @@ class MockedConfirmSignPetitionService {
   public get success$(): Observable<CodeSubmissionResult | undefined> {
     return of({
       __typename: 'CodeSubmissionResult',
-      error: false,
-      message: '',
+      id: '12345',
+      title: 'Mock Petition',
+      error: null,
     });
   }
   public get loading$(): Observable<boolean> {

--- a/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.spec.ts
+++ b/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.spec.ts
@@ -65,7 +65,7 @@ describe('ConfirmSignPetitionComponent', () => {
     fixture = TestBed.createComponent(ConfirmSignPetitionComponent);
     component = fixture.componentInstance;
     _getConfirmSignPetitionService = fixture.debugElement.injector.get(
-      ConfirmSignPetitionService
+      ConfirmSignPetitionService,
     );
   });
 
@@ -76,7 +76,7 @@ describe('ConfirmSignPetitionComponent', () => {
   it('must call the service when submitting with a valid form', () => {
     const callSpy = spyOn(
       _getConfirmSignPetitionService,
-      'setConfirmationCode'
+      'setConfirmationCode',
     );
     component.ngOnInit();
     component.formGroup.patchValue({ code: '123345' });
@@ -102,7 +102,7 @@ describe('ConfirmSignPetitionComponent', () => {
     spyOnProperty(
       _getConfirmSignPetitionService,
       'loading$',
-      'get'
+      'get',
     ).and.returnValue(of(false));
 
     component.ngOnInit();
@@ -119,13 +119,13 @@ describe('ConfirmSignPetitionComponent', () => {
     spyOnProperty(
       _getConfirmSignPetitionService,
       'error$',
-      'get'
+      'get',
     ).and.returnValue(of('error'));
 
     spyOnProperty(
       _getConfirmSignPetitionService,
       'loading$',
-      'get'
+      'get',
     ).and.returnValue(of(false));
 
     component.ngOnInit();
@@ -142,13 +142,13 @@ describe('ConfirmSignPetitionComponent', () => {
     spyOnProperty(
       _getConfirmSignPetitionService,
       'error$',
-      'get'
+      'get',
     ).and.returnValue(of('error'));
 
     spyOnProperty(
       _getConfirmSignPetitionService,
       'loading$',
-      'get'
+      'get',
     ).and.returnValue(of(true));
 
     component.ngOnInit();

--- a/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.ts
+++ b/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.ts
@@ -28,10 +28,10 @@ export class ConfirmSignPetitionComponent implements OnInit {
   ngOnInit(): void {
     this._confirmSignPetitionLogic.success$.subscribe((data) => {
       if (data?.error) {
-        this.localError$.next(data.message);
+        this.localError$.next(data.error);
       } else {
         this._router.navigate([
-          '/petition/result-confirm-code/' + data?.message,
+          '/petition/result-confirm-code/' + data?.title,
         ]);
       }
     });

--- a/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.ts
+++ b/src/app/features/sign-petition/confirm-sign-petition/confirm-sign-petition.component.ts
@@ -18,7 +18,7 @@ export class ConfirmSignPetitionComponent implements OnInit {
   constructor(
     private _fb: FormBuilder,
     private _confirmSignPetitionLogic: ConfirmSignPetitionService,
-    private _router: Router
+    private _router: Router,
   ) {
     this.formGroup = this._fb.group({
       code: ['', [Validators.required]],
@@ -30,21 +30,19 @@ export class ConfirmSignPetitionComponent implements OnInit {
       if (data?.error) {
         this.localError$.next(data.error);
       } else {
-        this._router.navigate([
-          '/petition/result-confirm-code/' + data?.title,
-        ]);
+        this._router.navigate(['/petition/result-confirm-code/' + data?.title]);
       }
     });
     this.loading$ = this._confirmSignPetitionLogic.loading$;
     this.error$ = merge(
       this._confirmSignPetitionLogic.error$,
-      this.localError$
+      this.localError$,
     );
   }
   submit() {
     if (this.formGroup.valid) {
       this._confirmSignPetitionLogic.setConfirmationCode(
-        this.formGroup.value.code
+        this.formGroup.value.code,
       );
     }
   }

--- a/src/app/logic/petition/petition.service.spec.ts
+++ b/src/app/logic/petition/petition.service.spec.ts
@@ -766,8 +766,9 @@ const _getVoterRecordMatchQuery: GetVoterRecordMatchQuery = {
 const _submitVerificationCodeMutation: SubmitVerificationCodeMutation = {
   submitVerificationCode: {
     __typename: 'CodeSubmissionResult',
-    error: false,
-    message: '',
+    id: '12345',
+    title: '',
+    error: null,
   },
 };
 

--- a/src/app/logic/petition/petition.service.spec.ts
+++ b/src/app/logic/petition/petition.service.spec.ts
@@ -38,7 +38,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _submitIssuePetitionMutation });
-      })
+      }),
     );
     service.newIssuePetition({ detail: '', title: '' }).subscribe((data) => {
       expect(data.result).toEqual(_issuePetition);
@@ -50,7 +50,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.newIssuePetition({ detail: '', title: '' }).subscribe((data) => {
@@ -63,7 +63,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _submitCandidatePetitionMutation });
-      })
+      }),
     );
     service
       .newCandidatePetition({
@@ -82,7 +82,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -102,7 +102,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _submitSignatureMutation });
-      })
+      }),
     );
     service
       .signPetition({
@@ -139,7 +139,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -163,7 +163,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getVoterRecordMatchQuery });
-      })
+      }),
     );
     service
       .getVoterRecordMatch({
@@ -192,7 +192,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -213,11 +213,11 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _submitVerificationCodeMutation });
-      })
+      }),
     );
     service.confirmSignaturePetition('').subscribe((data) => {
       expect(data.result).toEqual(
-        _submitVerificationCodeMutation.submitVerificationCode
+        _submitVerificationCodeMutation.submitVerificationCode,
       );
       done();
     });
@@ -227,7 +227,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.confirmSignaturePetition('').subscribe((data) => {
@@ -240,7 +240,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _editIssuePetitionMutation });
-      })
+      }),
     );
     service
       .editPetitionIssue({ expectedVersion: 0, PK: '' })
@@ -254,7 +254,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -269,7 +269,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _editCandidatePetitionMutation });
-      })
+      }),
     );
     service
       .editPetitionCandidate({ expectedVersion: 0, PK: '' })
@@ -283,7 +283,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -298,7 +298,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionQueryIssue });
-      })
+      }),
     );
     service.getPublicPetition('').subscribe((data) => {
       expect(data.result).toEqual({ dataIssue: _issuePetition });
@@ -310,7 +310,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionQueryCandidate });
-      })
+      }),
     );
     service.getPublicPetition('').subscribe((data) => {
       expect(data.result).toEqual({ dataCandidate: _candidatePetition });
@@ -322,7 +322,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getPublicPetition('').subscribe((data) => {
@@ -335,7 +335,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionQueryIssue });
-      })
+      }),
     );
     service.getCommitteePetition('').subscribe((data) => {
       expect(data.result).toEqual({ dataIssue: _issuePetition });
@@ -347,7 +347,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionQueryCandidate });
-      })
+      }),
     );
     service.getCommitteePetition('').subscribe((data) => {
       expect(data.result).toEqual({ dataCandidate: _candidatePetition });
@@ -359,7 +359,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getCommitteePetition('').subscribe((data) => {
@@ -372,7 +372,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionQueryIssue });
-      })
+      }),
     );
     service.getStaffPetition('').subscribe((data) => {
       expect(data.result).toEqual({ dataIssue: _issuePetition });
@@ -384,7 +384,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionQueryCandidate });
-      })
+      }),
     );
     service.getStaffPetition('').subscribe((data) => {
       expect(data.result).toEqual({ dataCandidate: _candidatePetition });
@@ -396,7 +396,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getStaffPetition('').subscribe((data) => {
@@ -409,7 +409,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _approveIssuePetitionMutation });
-      })
+      }),
     );
     service
       .approvePetition({
@@ -428,7 +428,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _approveCandidatePetitionMutation });
-      })
+      }),
     );
     service
       .approvePetition({
@@ -447,7 +447,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -467,7 +467,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _rejectIssuePetitionMutation });
-      })
+      }),
     );
     service
       .denyPetition({
@@ -484,7 +484,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _rejectCandidatePetitionMutation });
-      })
+      }),
     );
     service
       .denyPetition({
@@ -501,7 +501,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service
@@ -519,7 +519,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionsByOwnerQuery });
-      })
+      }),
     );
     service.getCommitteePetitions({ owner: '' }).subscribe((data) => {
       expect(data.result).toEqual({
@@ -537,7 +537,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getCommitteePetitions({ owner: '' }).subscribe((data) => {
@@ -550,7 +550,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionsByTypeQuery });
-      })
+      }),
     );
     service.getInactivePetitions({}).subscribe((data) => {
       expect(data.result).toEqual({
@@ -568,7 +568,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getInactivePetitions({}).subscribe((data) => {
@@ -581,7 +581,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionsByTypeQuery });
-      })
+      }),
     );
     service.getCityStaffPetitions({}).subscribe((data) => {
       expect(data.result).toEqual({
@@ -599,7 +599,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getCityStaffPetitions({}).subscribe((data) => {
@@ -612,7 +612,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionsByTypeQuery });
-      })
+      }),
     );
     service.getActivePetitions({}).subscribe((data) => {
       expect(data.result).toEqual({
@@ -630,7 +630,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getActivePetitions({}).subscribe((data) => {
@@ -643,7 +643,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         resolve({ data: _getPetitionsByTypeQuery });
-      })
+      }),
     );
     service.getAnonymousActivePetitions({}).subscribe((data) => {
       expect(data.result).toEqual({
@@ -661,7 +661,7 @@ describe('PetitionService', () => {
     API.graphql = jasmine.createSpy().and.returnValue(
       new Promise((resolve, reject) => {
         reject({ errors: [{ message: 'example' }] });
-      })
+      }),
     );
 
     service.getAnonymousActivePetitions({}).subscribe((data) => {

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -348,8 +348,9 @@ export const submitSignature = /* GraphQL */ `
 export const submitVerificationCode = /* GraphQL */ `
   mutation SubmitVerificationCode($code: ID!) {
     submitVerificationCode(code: $code) {
+      id
+      title
       error
-      message
     }
   }
 `;


### PR DESCRIPTION
# Overview

Updates the `confirm-sign-petition` component to display the petition title after using the code submission workflow. The backend has been updated to return the petition information instead of a generic message, so this process works the same as signature verification.

## Backend PR

https://github.com/maplight/Digital-Petitions-Backend/pull/41

## Task 

[DP-411](https://maplight.atlassian.net/browse/DP-411)

[DP-411]: https://maplight.atlassian.net/browse/DP-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ